### PR TITLE
fix: guard against empty betas in ParallelTemperingOptimizer::new

### DIFF
--- a/src/optim/parallel_tempering.rs
+++ b/src/optim/parallel_tempering.rs
@@ -39,6 +39,9 @@ impl ParallelTemperingOptimizer {
         betas: Vec<f64>,
         update_frequency: usize,
     ) -> Self {
+        if betas.is_empty() {
+            panic!("betas must contain at least one replica");
+        }
         Self {
             patience,
             n_trials,

--- a/src/tests/test_parallel_tempering.rs
+++ b/src/tests/test_parallel_tempering.rs
@@ -31,3 +31,9 @@ fn test_parallel_tempering_basic() {
 
     assert!(best_score.into_inner().is_finite());
 }
+
+#[test]
+#[should_panic(expected = "betas must contain at least one replica")]
+fn test_parallel_tempering_empty_betas() {
+    ParallelTemperingOptimizer::new(50, 10, 10, vec![], 5);
+}


### PR DESCRIPTION
Fixes #79.

`ParallelTemperingOptimizer::new` accepted an empty `betas` vec, which later underflows `0..(n_replicas - 1)` in the exchange loop (arithmetic-overflow panic in debug, index-out-of-bounds in release). `with_geometric_betas` already guards `n_replicas == 0`, so this adds the same check to `new` and a regression test.