### PR TITLE
fix: guard AcceptanceCounter::enqueue against zero-size window

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -27,6 +27,9 @@ impl AcceptanceCounter {
 
     /// Update the counter with a new result
     pub fn enqueue(&mut self, accepted: bool) {
+        if self.window_size == 0 {
+            return;
+        }
         if self.buffer.len() == self.window_size {
             let old = self.buffer.pop_front().unwrap();
             self.n_accepted -= old as usize;
@@ -44,5 +47,35 @@ impl AcceptanceCounter {
         } else {
             self.n_accepted as f64 / total as f64
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AcceptanceCounter;
+
+    #[test]
+    fn window_zero_enqueue_is_noop_and_does_not_panic() {
+        let mut c = AcceptanceCounter::new(0);
+
+        c.enqueue(true);
+        c.enqueue(false);
+
+        assert_eq!(c.acceptance_ratio(), 0.0);
+    }
+
+    #[test]
+    fn sliding_window_behavior_unchanged() {
+        let mut c = AcceptanceCounter::new(2);
+
+        c.enqueue(true);
+        c.enqueue(true);
+        assert_eq!(c.acceptance_ratio(), 1.0);
+
+        c.enqueue(false);
+        assert_eq!(c.acceptance_ratio(), 0.5);
+
+        c.enqueue(false);
+        assert_eq!(c.acceptance_ratio(), 0.0);
     }
 }


### PR DESCRIPTION
## Summary

`AcceptanceCounter::enqueue` panics when the counter is constructed with `window_size == 0`. On the first call the guard `self.buffer.len() == self.window_size` is `0 == 0`, so `self.buffer.pop_front().unwrap()` runs on an empty deque and panics with an unwrap-on-None error. `AcceptanceCounter::new` is public, so downstream code that constructs `new(0)` hits this even though the bundled optimizers currently hardcode `new(100)`.

## Motivation

A zero-size sliding window is a valid degenerate input: it should simply hold no samples rather than panic. This guards the public constructor path so callers get well-defined behavior instead of an unwrap panic.

## Changes

- `src/counter.rs`: short-circuit `enqueue` when `window_size == 0` so it becomes a no-op (buffer stays empty, `acceptance_ratio()` returns `0.0`). No change to the `window_size >= 1` sliding-eviction path.
- Added tests: a zero-window case (repeated `enqueue` does not panic and `acceptance_ratio()` stays `0.0`) and a normal window-of-2 case asserting the sliding ratios `1.0 -> 0.5 -> 0.0` are unchanged.

Closes #81
