### PR TITLE
feat(optim): add ALNS support via TrialGenerator abstraction

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ flowchart TD
     HasInitial -- "No (not provided)" --> Pre
     Pre --> Optim["Optimizer: optimize(...)"]
     Optim --> Update["handler.update(ctx) each iteration"]
-    Update --> LoopStart["generate n_trials candidates in parallel; keep best"]
+    Update --> LoopStart["generator.generate_trial(...) x n_trials; keep best"]
     LoopStart --> Eval["p = handler.evaluate(current, trial)"]
     Eval --> Decide{"accept? (p > rand(0, 1))"}
     Decide -- "Accept" --> Apply["apply trial -> new current"]
@@ -28,7 +28,7 @@ flowchart TD
 - Notes on the flow:
   - `generate_random_solution` is used when a caller does not provide an initial solution (helpers such as `LocalSearchOptimizer::run` call it). Implementations should produce a valid solution and its score.
   - `preprocess_solution` is executed before handing the solution to the optimizer (use for repairs, caching, or building auxiliary data structures).
-  - Inside the optimizer, `generate_trial_solution` is called repeatedly to propose neighbors; it returns the candidate solution, a `TransitionType` describing the change (useful for Tabu or undo operations), and the candidate score. Loop-based optimizers generate `n_trials` candidates per iteration in parallel (rayon) and keep the best-scoring one.
+  - Inside the optimizer, trial candidates come from a `TrialGenerator`. By default the loop drives `OptModel::generate_trial_solution` through `DefaultTrialGenerator`; the `n_trials` candidates per iteration are evaluated and the best-scoring one is kept. ALNS (and other adaptive schemes) plug in via `LocalSearchLoop::step_with_generator` or `GenericLocalSearchOptimizer::with_trial_generator` to drive trial generation through destroy/repair operators instead.
   - Acceptance is decided by a `TransitionHandler`: `handler.update` is invoked once per iteration before trials are generated (cooling schedules, water levels, etc.), then `handler.evaluate(current_score, trial_score)` returns the acceptance probability; the trial is accepted when `p > rand(0, 1)`. Improving transitions return `1.0` from the handler itself.
   - After optimization completes, `postprocess_solution` is called to finalize or decode the result for the user.
 
@@ -85,12 +85,30 @@ The acceptance/scheduling logic of each algorithm lives in a `TransitionHandler`
 
 - `LocalSearchLoop<ST>` (`src/optim/search_loop.rs`) — the trial-and-accept loop shared by every local-search optimizer. Constructed with `LocalSearchLoop::new(patience, n_trials, return_iter)`:
   - `patience` — give up (early stop) if the score has not improved for this many iterations.
-  - `n_trials` — number of trial candidates generated (in parallel) per iteration; the best is kept.
+  - `n_trials` — number of trial candidates generated per iteration; the best is kept.
   - `return_iter` — return to the best solution after this many non-improving iterations.
-- `LocalSearchLoop::step(model, initial_solution, initial_score, n_iter, time_limit, callback, handler) -> (StepResult<...>, H)` — runs up to `n_iter` iterations with the supplied handler and returns the `StepResult` plus the (possibly mutated) handler so per-run state survives the call. `LocalSearchLoop` itself stores no handler.
+- `LocalSearchLoop::step(model, initial_solution, initial_score, n_iter, time_limit, callback, handler) -> (StepResult<...>, H)` — runs up to `n_iter` iterations with the supplied handler and returns the `StepResult` plus the (possibly mutated) handler so per-run state survives the call. Trial generation goes through `DefaultTrialGenerator` (a thin wrapper over `OptModel::generate_trial_solution`). `LocalSearchLoop` itself stores no handler.
 - `StepResult<S, ST>` fields: `best_solution`, `best_score`, `last_solution`, `last_score`, `acceptance_counter: AcceptanceCounter`.
-- `GenericLocalSearchOptimizer<ST, H>` (`src/optim/generic.rs`) — owns a handler *blueprint*; each `optimize` call clones it, so the stored handler stays untouched across runs and can be reused. Implements `LocalSearchOptimizer<M>` for any `M: OptModel` / `H: TransitionHandler<M::ScoreType> + Clone`. Use it to drive an arbitrary handler through the standard optimizer interface; use `LocalSearchLoop` directly when you need the handler's post-run state.
+- `GenericLocalSearchOptimizer<ST, H, G = DefaultTrialGenerator>` (`src/optim/generic.rs`) — owns a handler *blueprint* and an optional trial generator; each `optimize` call clones both, so the stored values stay untouched across runs and can be reused. Implements `LocalSearchOptimizer<M>` for any `M: OptModel` / `H: TransitionHandler<M::ScoreType> + Clone` / `G: TrialGenerator<M> + Clone`. Use it to drive an arbitrary handler through the standard optimizer interface; use `LocalSearchLoop` directly when you need the handler's or generator's post-run state.
 - `AcceptanceCounter` (`src/counter.rs`, re-exported at crate root) — sliding-window acceptance counter (`new(window_size)`, `enqueue(accepted)`, `acceptance_ratio()`); window size 100 by default.
+
+## Trial generators and ALNS
+
+The trial-generation side of the search loop is pluggable through the `TrialGenerator` trait (`src/optim/search_loop.rs`). A generator produces one trial per `generate_trial` call and receives a `TrialOutcome` feedback once the loop knows what happened to that trial.
+
+- `TrialOutcome` (`src/optim/search_loop.rs`) — classifies the trial as `NewBest`, `Improved`, `Accepted`, or `Rejected`. Adaptive generators (ALNS) use this to credit operator weights.
+- `TrialGenerator<M: OptModel>` (`src/optim/search_loop.rs`) — `generate_trial(...)` and `feedback(outcome)`; object-safe so generators can be stored behind trait objects.
+- `DefaultTrialGenerator` (`src/optim/search_loop.rs`) — the default generator; just calls `OptModel::generate_trial_solution` and ignores feedback.
+- `LocalSearchLoop::step_with_generator(model, initial_solution, initial_score, n_iter, time_limit, callback, handler, generator) -> (StepResult<...>, H, G)` — same loop as `step`, but trial generation is driven by the supplied `generator`. The generator is returned alongside the result so its adapted state (e.g. ALNS weights) can be inspected.
+
+ALNS is built on top of this trait:
+
+- `DestroyOperator<M, P>` / `RepairOperator<M, P>` (`src/optim/alns.rs`) — traits the user implements to define destroy and repair operators. Operators must be `Send + Sync` and provide a `dyn_clone` method so the trait stays object-safe (a blanket `Clone` impl on `Box<dyn DestroyOperator<_, _>>` / `Box<dyn RepairOperator<_, _>>` delegates to `dyn_clone`).
+- `Rewards` (`src/optim/alns.rs`) — per-outcome reward table (`new_best`, `improved`, `accepted`, `rejected`); defaults follow Ropke & Pisinger (33 / 9 / 13 / 0).
+- `AlnsTrialGenerator<M, P>` (`src/optim/alns.rs`) — holds destroy and repair operator pools with independent roulette-wheel weights, segment-based weight updates, and a reaction-factor blending rule. Built with `AlnsTrialGenerator::new(destroy, repair)`; builder methods: `with_segment_size`, `with_reaction_factor`, `with_destroy_rewards`, `with_repair_rewards`, `with_rewards`. Inspected via `destroy_weights` / `repair_weights` / `destroy_usage` / `repair_usage` / `destroy_scores` / `repair_scores` / `trials_in_segment`.
+- `GenericLocalSearchOptimizer::with_trial_generator(generator)` — swaps in an ALNS generator (or any other `TrialGenerator`) for the default one; returns a new optimizer with the new generator type.
+
+See `src/tests/test_alns.rs` for a complete example.
 
 ## Concrete optimizers
 
@@ -123,9 +141,10 @@ Each optimizer instantiates its `TransitionHandler` in the constructor and store
 - `src/model.rs` (OptModel definition)
 - `src/optim/base.rs` (LocalSearchOptimizer + run/run_with_callback)
 - `src/optim/transition.rs` (TransitionHandler + UpdateCtx)
-- `src/optim/search_loop.rs` (LocalSearchLoop + StepResult)
+- `src/optim/search_loop.rs` (LocalSearchLoop, StepResult, TrialGenerator, TrialOutcome, DefaultTrialGenerator)
 - `src/optim/generic.rs` (GenericLocalSearchOptimizer)
 - `src/optim/handlers.rs` (per-algorithm handlers and tuning helpers)
+- `src/optim/alns.rs` (AlnsTrialGenerator, DestroyOperator, RepairOperator, Rewards)
 - `src/callback.rs` (OptProgress and OptCallbackFn)
 - `src/counter.rs` (AcceptanceCounter)
 - `src/time_wrapper.rs` (Duration / Instant re-exports)

--- a/API.md
+++ b/API.md
@@ -94,16 +94,16 @@ The acceptance/scheduling logic of each algorithm lives in a `TransitionHandler`
 
 ## Trial generators and ALNS
 
-The trial-generation side of the search loop is pluggable through the `TrialGenerator` trait (`src/optim/search_loop.rs`). A generator produces one trial per `generate_trial` call and receives a `TrialOutcome` feedback once the loop knows what happened to that trial.
+The trial-generation side of the search loop is pluggable through the `TrialGenerator` trait (`src/optim/search_loop.rs`). `generate_trial` takes `&self`, so the loop generates the `n_trials` candidates of each iteration in parallel via rayon — each trial draws from a per-trial `StdRng` fork seeded sequentially for reproducibility. Each trial returns a `Token` identifying its operators; only the winner's token is handed to `feedback(token, outcome)` (winner-takes-all).
 
 - `TrialOutcome` (`src/optim/search_loop.rs`) — classifies the trial as `NewBest`, `Improved`, `Accepted`, or `Rejected`. Adaptive generators (ALNS) use this to credit operator weights.
-- `TrialGenerator<M: OptModel>` (`src/optim/search_loop.rs`) — `generate_trial(...)` and `feedback(outcome)`; object-safe so generators can be stored behind trait objects.
+- `TrialGenerator<M: OptModel>` (`src/optim/search_loop.rs`) — `generate_trial(&self, model, &solution, score, rng) -> (solution, score, Token)` with `type Token: Send`, plus `feedback(&mut self, token, outcome)`. Implementations must be `Sync`.
 - `DefaultTrialGenerator` (`src/optim/search_loop.rs`) — the default generator; just calls `OptModel::generate_trial_solution` and ignores feedback.
 - `LocalSearchLoop::step_with_generator(model, initial_solution, initial_score, n_iter, time_limit, callback, handler, generator) -> (StepResult<...>, H, G)` — same loop as `step`, but trial generation is driven by the supplied `generator`. The generator is returned alongside the result so its adapted state (e.g. ALNS weights) can be inspected.
 
 ALNS is built on top of this trait:
 
-- `DestroyOperator<M, P>` / `RepairOperator<M, P>` (`src/optim/alns.rs`) — traits the user implements to define destroy and repair operators. Operators must be `Send + Sync` and provide a `dyn_clone` method so the trait stays object-safe (a blanket `Clone` impl on `Box<dyn DestroyOperator<_, _>>` / `Box<dyn RepairOperator<_, _>>` delegates to `dyn_clone`).
+- `DestroyOperator<M, P>` / `RepairOperator<M, P>` (`src/optim/alns.rs`) — traits the user implements to define destroy and repair operators. Operators receive the loop's per-trial `StdRng` fork and a borrowed solution (`destroy(&self, model, &solution, rng)`), so all randomness flows from the loop and stays reproducible. Operators must be `Send + Sync` and provide a `dyn_clone` method so the trait stays object-safe (a blanket `Clone` impl on `Box<dyn DestroyOperator<_, _>>` / `Box<dyn RepairOperator<_, _>>` delegates to `dyn_clone`).
 - `Rewards` (`src/optim/alns.rs`) — per-outcome reward table (`new_best`, `improved`, `accepted`, `rejected`); defaults follow Ropke & Pisinger (33 / 9 / 13 / 0).
 - `AlnsTrialGenerator<M, P>` (`src/optim/alns.rs`) — holds destroy and repair operator pools with independent roulette-wheel weights, segment-based weight updates, and a reaction-factor blending rule. Built with `AlnsTrialGenerator::new(destroy, repair)`; builder methods: `with_segment_size`, `with_reaction_factor`, `with_destroy_rewards`, `with_repair_rewards`, `with_rewards`. Inspected via `destroy_weights` / `repair_weights` / `destroy_usage` / `repair_usage` / `destroy_scores` / `repair_scores` / `trials_in_segment`.
 - `GenericLocalSearchOptimizer::with_trial_generator(generator)` — swaps in an ALNS generator (or any other `TrialGenerator`) for the default one; returns a new optimizer with the new generator type.

--- a/examples/tsp_alns_model.rs
+++ b/examples/tsp_alns_model.rs
@@ -555,7 +555,7 @@ fn main() {
     );
     let generator = build_alns_generator();
     let optimizer: GenericLocalSearchOptimizer<ScoreType, TsallisAnnealing, _> =
-        GenericLocalSearchOptimizer::new(patience, 1, return_iter, handler)
+        GenericLocalSearchOptimizer::new(patience, 8, return_iter, handler)
             .with_trial_generator(generator);
 
     println!("run ALNS");

--- a/examples/tsp_alns_model.rs
+++ b/examples/tsp_alns_model.rs
@@ -1,0 +1,594 @@
+//! Solve the Travelling Salesman Problem with Adaptive Large Neighborhood
+//! Search (ALNS).
+//!
+//! Each iteration picks one destroy operator (e.g. random-removal,
+//! worst-removal) and one repair operator (greedy-insertion,
+//! random-insertion) via independent roulette-wheel draws. After the trial
+//! is scored by the acceptance handler, the chosen operators are credited
+//! according to the outcome and their weights are blended at every segment
+//! boundary using the reaction-factor rule from Ropke & Pisinger (2006).
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --example tsp_alns_model --release -- <input_file> [opt_route_file]
+//! ```
+//!
+//! `<input_file>` contains one city per line as `<id> <x> <y>`. The optional
+//! `<opt_route_file>` holds an optimal tour as one city id per line; when
+//! supplied, the example prints the gap against the optimum at the end.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::{self, BufRead},
+    num::NonZero,
+    path::Path,
+    time::Duration,
+};
+
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use localsearch::{
+    LocalsearchError, OptModel, OptProgress,
+    optim::{
+        AdaptiveScheduler, AlnsTrialGenerator, DestroyOperator, GenericLocalSearchOptimizer,
+        LocalSearchOptimizer, RepairOperator, TargetAccScheduleMode, TsallisAnnealing,
+    },
+};
+use ordered_float::NotNan;
+use rand::{RngExt as _, seq::SliceRandom};
+
+// ---------------------------------------------------------------------------
+// TSP model
+// ---------------------------------------------------------------------------
+
+type Edge = (usize, usize);
+type SolutionType = Vec<usize>;
+/// Partial tour during ALNS: `(tour_with_gaps, removed_cities)`. Positions
+/// in `tour_with_gaps` are fixed; `None` slots mark cities that have been
+/// destroyed and still need to be reinserted.
+type PartialTour = (Vec<Option<usize>>, Vec<usize>);
+type ScoreType = NotNan<f64>;
+
+fn min_sorted(c1: usize, c2: usize) -> (usize, usize) {
+    if c1 < c2 { (c1, c2) } else { (c2, c1) }
+}
+
+#[derive(Clone, Debug)]
+struct TSPModel {
+    start: usize,
+    distance_matrix: HashMap<Edge, f64>,
+}
+
+impl TSPModel {
+    fn new(start: usize, distance_matrix: HashMap<Edge, f64>) -> Self {
+        Self {
+            start,
+            distance_matrix,
+        }
+    }
+
+    fn from_coords(coords: &[(usize, f64, f64)]) -> TSPModel {
+        let start = coords.iter().map(|(i, _, _)| *i).min().unwrap();
+        let mut mat = HashMap::new();
+        for &(c1, x1, y1) in coords {
+            for &(c2, x2, y2) in coords {
+                if c1 == c2 {
+                    // Self-loops are queried by Shaw removal when ranking
+                    // cities against their own seed; keep the entry at 0.
+                    let key = min_sorted(c1, c2);
+                    mat.insert(key, 0.0);
+                    continue;
+                }
+                let key = min_sorted(c1, c2);
+                if mat.contains_key(&key) {
+                    continue;
+                }
+                let dist = ((x1 - x2).powf(2.0) + (y1 - y2).powf(2.0)).sqrt();
+                mat.insert(key, dist);
+            }
+        }
+        TSPModel::new(start, mat)
+    }
+
+    fn get_distance(&self, key: &(usize, usize)) -> f64 {
+        self.distance_matrix[key]
+    }
+
+    fn evaluate_solution(&self, solution: &SolutionType) -> ScoreType {
+        let score = (0..solution.len() - 1)
+            .map(|i| {
+                let key = min_sorted(solution[i], solution[i + 1]);
+                self.get_distance(&key)
+            })
+            .sum();
+        NotNan::new(score).unwrap()
+    }
+}
+
+impl OptModel for TSPModel {
+    type SolutionType = SolutionType;
+    type TransitionType = ();
+    type ScoreType = ScoreType;
+
+    fn generate_random_solution<R: rand::Rng>(
+        &self,
+        rng: &mut R,
+    ) -> Result<(Self::SolutionType, Self::ScoreType), LocalsearchError> {
+        let mut cities = self
+            .distance_matrix
+            .keys()
+            .copied()
+            .flat_map(|(i, j)| [i, j])
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        cities.shuffle(rng);
+
+        // Pin start at index 0 and close the tour by repeating it at the end.
+        let i = cities.iter().position(|&c| c == self.start).unwrap();
+        cities.swap(0, i);
+        cities.push(self.start);
+
+        let score = self.evaluate_solution(&cities);
+        Ok((cities, score))
+    }
+
+    fn generate_trial_solution<R: rand::Rng>(
+        &self,
+        current_solution: Self::SolutionType,
+        current_score: Self::ScoreType,
+        _rng: &mut R,
+    ) -> (Self::SolutionType, Self::TransitionType, Self::ScoreType) {
+        // Unused: ALNS short-circuits trial generation via
+        // `TrialGenerator::generate_trial`, so this default is a no-op.
+        (current_solution, (), current_score)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Destroy operators
+// ---------------------------------------------------------------------------
+
+/// Remove a random fraction of interior cities. `min_frac`/`max_frac`
+/// bracket the share of cities destroyed per call.
+#[derive(Clone)]
+struct RandomRemoval {
+    min_frac: f64,
+    max_frac: f64,
+}
+
+impl DestroyOperator<TSPModel, PartialTour> for RandomRemoval {
+    fn destroy(&self, _model: &TSPModel, solution: SolutionType) -> PartialTour {
+        let mut rng = rand::rng();
+        let n = solution.len() - 2; // exclude the start city pinned at both ends
+        let frac = rng.random_range(self.min_frac..=self.max_frac);
+        let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
+
+        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut interior: Vec<usize> = (1..partial.len() - 1).collect();
+        interior.shuffle(&mut rng);
+        let mut removed = Vec::with_capacity(n_remove);
+        for &i in interior.iter().take(n_remove) {
+            // SAFETY: interior only references indices 1..len-1, all of which
+            // hold `Some` at this point.
+            removed.push(partial[i].unwrap());
+            partial[i] = None;
+        }
+        (partial, removed)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<TSPModel, PartialTour>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Remove the cities whose removal saves the most distance — the "worst"
+/// positions in the current tour. The same fraction range as
+/// [`RandomRemoval`] is used.
+#[derive(Clone)]
+struct WorstRemoval {
+    min_frac: f64,
+    max_frac: f64,
+}
+
+impl DestroyOperator<TSPModel, PartialTour> for WorstRemoval {
+    fn destroy(&self, model: &TSPModel, solution: SolutionType) -> PartialTour {
+        let mut rng = rand::rng();
+        let n = solution.len() - 2;
+        let frac = rng.random_range(self.min_frac..=self.max_frac);
+        let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
+
+        // Saving of removing interior city at index i:
+        // d(prev, i) + d(i, next) - d(prev, next).
+        let mut savings: Vec<(usize, f64)> = Vec::with_capacity(n);
+        for i in 1..solution.len() - 1 {
+            let prev = solution[i - 1];
+            let cur = solution[i];
+            let next = solution[i + 1];
+            let save = model.get_distance(&min_sorted(prev, cur))
+                + model.get_distance(&min_sorted(cur, next))
+                - model.get_distance(&min_sorted(prev, next));
+            savings.push((i, save));
+        }
+        // Highest savings first.
+        savings.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut removed = Vec::with_capacity(n_remove);
+        for &(i, _) in savings.iter().take(n_remove) {
+            removed.push(partial[i].unwrap());
+            partial[i] = None;
+        }
+        (partial, removed)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<TSPModel, PartialTour>> {
+        Box::new(self.clone())
+    }
+}
+/// Remove a contiguous cluster of related cities around a random seed.
+///
+/// Shaw removal (Shaw & Cordeau, 1997) destroys cities that are close in the
+/// distance matrix, which keeps the rest of the tour tightly connected and
+/// lets repair recombine good local structure. Combined with random/worst
+/// removal it gives the ALNS pool enough diversity.
+#[derive(Clone)]
+struct ShawRemoval {
+    min_frac: f64,
+    max_frac: f64,
+}
+
+impl DestroyOperator<TSPModel, PartialTour> for ShawRemoval {
+    fn destroy(&self, model: &TSPModel, solution: SolutionType) -> PartialTour {
+        let mut rng = rand::rng();
+        let n = solution.len() - 2;
+        let frac = rng.random_range(self.min_frac..=self.max_frac);
+        let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
+
+        // Pick a random interior seed; rank every other interior city by
+        // distance to it, then take the `n_remove` nearest (the seed itself
+        // is included with distance 0).
+        let seed_idx = rng.random_range(1..solution.len() - 1);
+        let seed = solution[seed_idx];
+        let mut related: Vec<(usize, f64)> = (1..solution.len() - 1)
+            .map(|i| (i, model.get_distance(&min_sorted(seed, solution[i]))))
+            .collect();
+        related.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut removed = Vec::with_capacity(n_remove);
+        for &(i, _) in related.iter().take(n_remove) {
+            removed.push(partial[i].unwrap());
+            partial[i] = None;
+        }
+        (partial, removed)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<TSPModel, PartialTour>> {
+        Box::new(self.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+/// Walk the partial tour and return the index of the nearest present city
+/// to the left (resp. right) of position `i`. Both endpoints are pinned to
+/// the start city, so an answer is guaranteed for any interior index.
+fn neighbours(partial: &[Option<usize>], i: usize) -> (usize, usize) {
+    let prev = (0..i)
+        .rev()
+        .find_map(|j| partial[j])
+        .expect("partial tour must contain a city left of any interior gap");
+    let next = (i + 1..partial.len())
+        .find_map(|j| partial[j])
+        .expect("partial tour must contain a city right of any interior gap");
+    (prev, next)
+}
+/// 2-opt local search: repeatedly reverse every improving subsegment.
+///
+/// Returns `true` if any reversal was applied during the pass.
+fn two_opt_pass(model: &TSPModel, sol: &mut SolutionType) -> bool {
+    let n = sol.len();
+    if n < 4 {
+        return false;
+    }
+    // sol = [start, c1, ..., ck, start]. The interior is 1..n-1; the last
+    // entry equals the start city and stays pinned.
+    let mut improved = false;
+    for i in 1..n - 2 {
+        for j in (i + 1)..n - 1 {
+            // Old edges: (sol[i-1], sol[i]), (sol[j], sol[j+1]).
+            // New edges after reversing sol[i..=j]: (sol[i-1], sol[j]), (sol[i], sol[j+1]).
+            let a = sol[i - 1];
+            let b = sol[i];
+            let c = sol[j];
+            let d = sol[j + 1];
+            let old = model.get_distance(&min_sorted(a, b)) + model.get_distance(&min_sorted(c, d));
+            let new = model.get_distance(&min_sorted(a, c)) + model.get_distance(&min_sorted(b, d));
+            if new + 1e-9 < old {
+                sol[i..=j].reverse();
+                improved = true;
+            }
+        }
+    }
+    improved
+}
+
+/// Iterate 2-opt until a pass produces no improvement.
+fn two_opt(model: &TSPModel, mut sol: SolutionType) -> SolutionType {
+    while two_opt_pass(model, &mut sol) {}
+    sol
+}
+
+/// Insert every removed city at the gap with the smallest insertion cost.
+#[derive(Clone)]
+struct GreedyInsertion;
+
+impl RepairOperator<TSPModel, PartialTour> for GreedyInsertion {
+    fn repair(
+        &self,
+        model: &TSPModel,
+        (mut partial, mut removed): PartialTour,
+    ) -> (SolutionType, ScoreType) {
+        let mut rng = rand::rng();
+        // Process removed cities in random order to break symmetry.
+        removed.shuffle(&mut rng);
+
+        for city in removed {
+            let mut best_pos = 0;
+            let mut best_cost = f64::INFINITY;
+            for (i, slot) in partial.iter().enumerate() {
+                if slot.is_some() {
+                    continue;
+                }
+                let (prev, next) = neighbours(&partial, i);
+                let cost = model.get_distance(&min_sorted(prev, city))
+                    + model.get_distance(&min_sorted(city, next))
+                    - model.get_distance(&min_sorted(prev, next));
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_pos = i;
+                }
+            }
+            partial[best_pos] = Some(city);
+            let _ = &mut rng; // silence unused-mut when n_remove == 0
+        }
+
+        let solution: SolutionType = partial.into_iter().map(|s| s.unwrap()).collect();
+        // Local-search polish: iterate 2-opt until no improving reversal is
+        // left. This is the single biggest quality driver for TSP ALNS —
+        // greedy insertion alone plateaus well above optimum.
+        let solution = two_opt(model, solution);
+        let score = model.evaluate_solution(&solution);
+        (solution, score)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn RepairOperator<TSPModel, PartialTour>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Insert every removed city at a uniformly random gap.
+#[derive(Clone)]
+struct RandomInsertion;
+
+impl RepairOperator<TSPModel, PartialTour> for RandomInsertion {
+    fn repair(
+        &self,
+        _model: &TSPModel,
+        (mut partial, mut removed): PartialTour,
+    ) -> (SolutionType, ScoreType) {
+        let mut rng = rand::rng();
+        removed.shuffle(&mut rng);
+
+        for city in removed {
+            let gaps: Vec<usize> = partial
+                .iter()
+                .enumerate()
+                .filter_map(|(i, s)| if s.is_none() { Some(i) } else { None })
+                .collect();
+            // gaps is non-empty: every removed city has at least one open slot.
+            let pos = gaps[rng.random_range(0..gaps.len())];
+            partial[pos] = Some(city);
+        }
+
+        let solution: SolutionType = partial.into_iter().map(|s| s.unwrap()).collect();
+        // Score is recomputed from scratch — cheap relative to destroy.
+        let score = _model.evaluate_solution(&solution);
+        (solution, score)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn RepairOperator<TSPModel, PartialTour>> {
+        Box::new(self.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Operator pool assembly
+// ---------------------------------------------------------------------------
+
+fn destroy_operators() -> Vec<Box<dyn DestroyOperator<TSPModel, PartialTour>>> {
+    // Tighter fractions than the textbook 10-30%: greedy+2-opt already
+    // reconstructs well from a small destruction, and smaller gaps mean
+    // more iterations of meaningful search within the same iteration budget.
+    vec![
+        Box::new(RandomRemoval {
+            min_frac: 0.05,
+            max_frac: 0.15,
+        }),
+        Box::new(WorstRemoval {
+            min_frac: 0.05,
+            max_frac: 0.15,
+        }),
+        Box::new(ShawRemoval {
+            min_frac: 0.05,
+            max_frac: 0.15,
+        }),
+    ]
+}
+
+fn repair_operators() -> Vec<Box<dyn RepairOperator<TSPModel, PartialTour>>> {
+    vec![Box::new(GreedyInsertion), Box::new(RandomInsertion)]
+}
+
+fn build_alns_generator() -> AlnsTrialGenerator<TSPModel, PartialTour> {
+    AlnsTrialGenerator::new(destroy_operators(), repair_operators())
+        .with_segment_size(100)
+        .with_reaction_factor(0.3)
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}
+
+fn create_pbar(n_iter: u64) -> ProgressBar {
+    let pb = ProgressBar::new(n_iter);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} (eta={eta}) {msg} ",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+    pb.set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
+    pb
+}
+
+fn print_usage(program: &str) {
+    eprintln!("Usage: {program} <input_file> [opt_route_file]");
+    eprintln!();
+    eprintln!("Arguments:");
+    eprintln!("  <input_file>       TSP coordinates file (<id> <x> <y> per line)");
+    eprintln!("  [opt_route_file]   optional file with optimal route (one city id per line)");
+}
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let program = args
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "tsp_alns_model".to_string());
+
+    let mut input_file: Option<String> = None;
+    let mut opt_route_file: Option<String> = None;
+
+    let mut idx = 1;
+    while idx < args.len() {
+        let arg = args[idx].as_str();
+        if arg == "--help" || arg == "-h" {
+            print_usage(&program);
+            return;
+        } else if arg.starts_with('-') {
+            eprintln!("error: unknown option '{arg}'");
+            print_usage(&program);
+            std::process::exit(2);
+        } else if input_file.is_none() {
+            input_file = Some(args[idx].clone());
+        } else if opt_route_file.is_none() {
+            opt_route_file = Some(args[idx].clone());
+        } else {
+            eprintln!("error: unexpected positional argument '{}'", args[idx]);
+            print_usage(&program);
+            std::process::exit(2);
+        }
+        idx += 1;
+    }
+
+    let Some(input_file) = input_file else {
+        print_usage(&program);
+        std::process::exit(2);
+    };
+
+    let coords = read_lines(&input_file)
+        .unwrap()
+        .map(|line| {
+            let line = line.unwrap();
+            let splt = line.split(' ').collect::<Vec<_>>();
+            let id: usize = splt[0].parse().unwrap();
+            let x: f64 = splt[1].parse().unwrap();
+            let y: f64 = splt[2].parse().unwrap();
+            (id, x, y)
+        })
+        .collect::<Vec<_>>();
+
+    let tsp_model = TSPModel::from_coords(&coords);
+
+    let n_iter: usize = 100_000;
+    let return_iter = n_iter / 50;
+    let time_limit = Duration::from_secs(120);
+    let patience = n_iter / 2;
+
+    let mut rng = rand::rng();
+    let initial_solution = tsp_model.generate_random_solution(&mut rng).ok();
+
+    let pb = create_pbar(n_iter as u64);
+    let mut callback = |op: OptProgress<SolutionType, ScoreType>| {
+        pb.set_message(format!(
+            "best score {:.4e}, acceptance ratio {:.2}",
+            op.score.into_inner(),
+            op.acceptance_ratio
+        ));
+        pb.set_position(op.iter as u64);
+    };
+
+    // ALNS trial generator + Tsallis relative-annealing acceptance handler,
+    // glued through the generic optimizer entry point. The Tsallis offset is
+    // seeded from the initial random tour's score so that the first iteration's
+    // denominator is well-defined.
+    let initial_score = initial_solution
+        .as_ref()
+        .expect("random initial solution")
+        .1
+        .into_inner();
+    let handler = TsallisAnnealing::new(
+        initial_score,
+        1.0e2,
+        2.0,
+        2.0,
+        AdaptiveScheduler::new(0.3, 0.3, TargetAccScheduleMode::Constant, 0.10),
+        NonZero::new(100).expect("update_frequency must be >= 1"),
+    );
+    let generator = build_alns_generator();
+    let optimizer: GenericLocalSearchOptimizer<ScoreType, TsallisAnnealing, _> =
+        GenericLocalSearchOptimizer::new(patience, 1, return_iter, handler)
+            .with_trial_generator(generator);
+
+    println!("run ALNS");
+    pb.reset();
+    let (sol, score) = optimizer
+        .run_with_callback(
+            &tsp_model,
+            initial_solution,
+            n_iter,
+            time_limit,
+            &mut callback,
+        )
+        .unwrap();
+    pb.finish_and_clear();
+    println!("ALNS: final score = {}, num of cities {}", score, sol.len());
+
+    let Some(opt_route_file) = opt_route_file else {
+        return;
+    };
+    let opt_solution = read_lines(opt_route_file)
+        .unwrap()
+        .map(|line| line.unwrap().parse::<usize>().unwrap())
+        .collect::<Vec<_>>();
+    let opt_score = tsp_model.evaluate_solution(&opt_solution);
+    println!(
+        "optimal score = {}, num of cities {}",
+        opt_score,
+        opt_solution.len()
+    );
+    let gap = (score.into_inner() - opt_score.into_inner()) / opt_score.into_inner() * 100.0;
+    println!("gap = {gap:.3}%");
+}

--- a/examples/tsp_alns_model.rs
+++ b/examples/tsp_alns_model.rs
@@ -36,7 +36,7 @@ use localsearch::{
     },
 };
 use ordered_float::NotNan;
-use rand::{RngExt as _, seq::SliceRandom};
+use rand::{RngExt as _, rngs::StdRng, seq::SliceRandom};
 
 // ---------------------------------------------------------------------------
 // TSP model
@@ -159,15 +159,14 @@ struct RandomRemoval {
 }
 
 impl DestroyOperator<TSPModel, PartialTour> for RandomRemoval {
-    fn destroy(&self, _model: &TSPModel, solution: SolutionType) -> PartialTour {
-        let mut rng = rand::rng();
+    fn destroy(&self, _model: &TSPModel, solution: &SolutionType, rng: &mut StdRng) -> PartialTour {
         let n = solution.len() - 2; // exclude the start city pinned at both ends
         let frac = rng.random_range(self.min_frac..=self.max_frac);
         let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
 
-        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut partial: Vec<Option<usize>> = solution.iter().copied().map(Some).collect();
         let mut interior: Vec<usize> = (1..partial.len() - 1).collect();
-        interior.shuffle(&mut rng);
+        interior.shuffle(rng);
         let mut removed = Vec::with_capacity(n_remove);
         for &i in interior.iter().take(n_remove) {
             // SAFETY: interior only references indices 1..len-1, all of which
@@ -193,8 +192,7 @@ struct WorstRemoval {
 }
 
 impl DestroyOperator<TSPModel, PartialTour> for WorstRemoval {
-    fn destroy(&self, model: &TSPModel, solution: SolutionType) -> PartialTour {
-        let mut rng = rand::rng();
+    fn destroy(&self, model: &TSPModel, solution: &SolutionType, rng: &mut StdRng) -> PartialTour {
         let n = solution.len() - 2;
         let frac = rng.random_range(self.min_frac..=self.max_frac);
         let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
@@ -214,7 +212,7 @@ impl DestroyOperator<TSPModel, PartialTour> for WorstRemoval {
         // Highest savings first.
         savings.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
-        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut partial: Vec<Option<usize>> = solution.iter().copied().map(Some).collect();
         let mut removed = Vec::with_capacity(n_remove);
         for &(i, _) in savings.iter().take(n_remove) {
             removed.push(partial[i].unwrap());
@@ -240,8 +238,7 @@ struct ShawRemoval {
 }
 
 impl DestroyOperator<TSPModel, PartialTour> for ShawRemoval {
-    fn destroy(&self, model: &TSPModel, solution: SolutionType) -> PartialTour {
-        let mut rng = rand::rng();
+    fn destroy(&self, model: &TSPModel, solution: &SolutionType, rng: &mut StdRng) -> PartialTour {
         let n = solution.len() - 2;
         let frac = rng.random_range(self.min_frac..=self.max_frac);
         let n_remove = (((n as f64) * frac).round() as usize).clamp(1, n);
@@ -256,7 +253,7 @@ impl DestroyOperator<TSPModel, PartialTour> for ShawRemoval {
             .collect();
         related.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
 
-        let mut partial: Vec<Option<usize>> = solution.into_iter().map(Some).collect();
+        let mut partial: Vec<Option<usize>> = solution.iter().copied().map(Some).collect();
         let mut removed = Vec::with_capacity(n_remove);
         for &(i, _) in related.iter().take(n_remove) {
             removed.push(partial[i].unwrap());
@@ -329,10 +326,10 @@ impl RepairOperator<TSPModel, PartialTour> for GreedyInsertion {
         &self,
         model: &TSPModel,
         (mut partial, mut removed): PartialTour,
+        rng: &mut StdRng,
     ) -> (SolutionType, ScoreType) {
-        let mut rng = rand::rng();
         // Process removed cities in random order to break symmetry.
-        removed.shuffle(&mut rng);
+        removed.shuffle(rng);
 
         for city in removed {
             let mut best_pos = 0;
@@ -351,7 +348,6 @@ impl RepairOperator<TSPModel, PartialTour> for GreedyInsertion {
                 }
             }
             partial[best_pos] = Some(city);
-            let _ = &mut rng; // silence unused-mut when n_remove == 0
         }
 
         let solution: SolutionType = partial.into_iter().map(|s| s.unwrap()).collect();
@@ -377,9 +373,9 @@ impl RepairOperator<TSPModel, PartialTour> for RandomInsertion {
         &self,
         _model: &TSPModel,
         (mut partial, mut removed): PartialTour,
+        rng: &mut StdRng,
     ) -> (SolutionType, ScoreType) {
-        let mut rng = rand::rng();
-        removed.shuffle(&mut rng);
+        removed.shuffle(rng);
 
         for city in removed {
             let gaps: Vec<usize> = partial

--- a/src/optim.rs
+++ b/src/optim.rs
@@ -1,6 +1,7 @@
 //! Optimization Algorithm
 
 mod adaptive_annealing;
+mod alns;
 mod base;
 mod epsilon_greedy;
 mod generic;
@@ -20,6 +21,7 @@ mod transition;
 mod tsallis;
 
 pub use adaptive_annealing::AdaptiveAnnealingOptimizer;
+pub use alns::{AlnsTrialGenerator, DestroyOperator, RepairOperator, Rewards};
 pub use base::LocalSearchOptimizer;
 pub use epsilon_greedy::EpsilonGreedyOptimizer;
 pub use generic::GenericLocalSearchOptimizer;
@@ -39,7 +41,9 @@ pub use parallel_tempering::ParallelTemperingOptimizer;
 pub use population_annealing::PopulationAnnealingOptimizer;
 pub use random::RandomSearchOptimizer;
 pub use relative_annealing::RelativeAnnealingOptimizer;
-pub use search_loop::{LocalSearchLoop, StepResult};
+pub use search_loop::{
+    DefaultTrialGenerator, LocalSearchLoop, StepResult, TrialGenerator, TrialOutcome,
+};
 pub use simulated_annealing::SimulatedAnnealingOptimizer;
 pub use tabu_search::{TabuList, TabuSearchOptimizer};
 pub use transition::{TransitionHandler, UpdateCtx};

--- a/src/optim/alns.rs
+++ b/src/optim/alns.rs
@@ -1,0 +1,511 @@
+//! Adaptive Large Neighborhood Search (ALNS).
+//!
+//! This module implements the trial-generator side of ALNS as a
+//! [`TrialGenerator`](super::search_loop::TrialGenerator). The acceptance
+//! side stays in the regular
+//! [`TransitionHandler`](super::transition::TransitionHandler) machinery;
+//! ALNS only contributes the destroy/repair operator selection and the
+//! adaptive weight updates.
+//!
+//! # Overview
+//!
+//! Each iteration of the search loop calls
+//! [`TrialGenerator::generate_trial`](super::search_loop::TrialGenerator::generate_trial).
+//! The generator:
+//!
+//! 1. picks a destroy operator via roulette-wheel selection over its
+//!    weights,
+//! 2. picks a repair operator the same way (independently),
+//! 3. applies `destroy` to produce a partial state `P`,
+//! 4. applies `repair` to turn `P` back into a full
+//!    `(solution, score)` pair.
+//!
+//! Once the loop knows what happened to that trial, it calls
+//! [`TrialGenerator::feedback`](super::search_loop::TrialGenerator::feedback)
+//! with a [`TrialOutcome`](super::search_loop::TrialOutcome). The selected
+//! destroy and repair operators accumulate the corresponding reward and the
+//! trial counter advances. At every segment boundary the operator weights
+//! are recomputed with the reaction-factor blending rule from
+//! Ropke & Pisinger (2006).
+//!
+//! See `src/tests/test_alns.rs` for a complete example.
+
+use std::marker::PhantomData;
+
+use rand::RngExt as _;
+
+use super::search_loop::{TrialGenerator, TrialOutcome};
+use crate::OptModel;
+
+/// Per-outcome reward table for ALNS operator credit.
+///
+/// Defaults follow the widely used Ropke & Pisinger scheme: a new global
+/// best is worth the most, an improvement over the current solution is
+/// rewarded less, accepting a non-improving solution gets a small reward,
+/// and a rejected trial contributes nothing.
+#[derive(Debug, Clone, Copy)]
+pub struct Rewards {
+    /// Reward for a trial that produced a new global best.
+    pub new_best: f64,
+    /// Reward for a trial that improved over the current solution but did
+    /// not become the new global best.
+    pub improved: f64,
+    /// Reward for a trial that was accepted without improving the current
+    /// solution.
+    pub accepted: f64,
+    /// Reward for a trial that was rejected by the acceptance criterion.
+    pub rejected: f64,
+}
+
+impl Rewards {
+    /// Construct a reward table from the four outcome values.
+    pub const fn new(new_best: f64, improved: f64, accepted: f64, rejected: f64) -> Self {
+        Self {
+            new_best,
+            improved,
+            accepted,
+            rejected,
+        }
+    }
+
+    /// Look up the reward for a given [`TrialOutcome`].
+    fn reward_for(&self, outcome: TrialOutcome) -> f64 {
+        match outcome {
+            TrialOutcome::NewBest => self.new_best,
+            TrialOutcome::Improved => self.improved,
+            TrialOutcome::Accepted => self.accepted,
+            TrialOutcome::Rejected => self.rejected,
+        }
+    }
+}
+
+impl Default for Rewards {
+    fn default() -> Self {
+        // Classic Ropke & Pisinger weights.
+        Self {
+            new_best: 33.0,
+            improved: 9.0,
+            accepted: 13.0,
+            rejected: 0.0,
+        }
+    }
+}
+
+/// Adaptive weight and bookkeeping state for a single operator.
+#[derive(Debug, Clone, Copy)]
+pub struct OperatorStats {
+    /// Roulette-wheel weight used for selection.
+    pub weight: f64,
+    /// Accumulated reward for the current segment.
+    pub accumulated_score: f64,
+    /// Number of times the operator was applied during the current segment.
+    pub usage_count: usize,
+}
+
+impl OperatorStats {
+    const fn new(weight: f64) -> Self {
+        Self {
+            weight,
+            accumulated_score: 0.0,
+            usage_count: 0,
+        }
+    }
+}
+
+/// Plug-in destroy operator for ALNS.
+///
+/// A destroy operator returns a *partial* state of type `P`. The partial
+/// state is intentionally free-form — it can be a subset of indices that
+/// were removed, a set of moves to undo, or anything the matching
+/// [`RepairOperator`] knows how to interpret.
+///
+/// Implementors create their own RNG internally via [`rand::rng()`] (or any
+/// other source) so that the trait stays object-safe and operators can be
+/// stored as `Box<dyn DestroyOperator<_, _>>`.
+///
+/// Object-safety is preserved by providing a [`Self::dyn_clone`] method
+/// instead of adding [`Clone`] as a supertrait (which would force
+/// `Self: Sized`). A blanket [`Clone`] impl on `Box<dyn DestroyOperator<_, _>>`
+/// delegates to `dyn_clone`, so operators only need to be `Clone` for the
+/// concrete type — see the example in `src/tests/test_alns.rs`.
+pub trait DestroyOperator<M: OptModel, P>: Send + Sync {
+    /// Apply the destroy step and produce a partial state.
+    fn destroy(&self, model: &M, solution: M::SolutionType) -> P;
+    /// Clone the operator into a `Box<dyn DestroyOperator>`. Implementors
+    /// typically write `Box::new(self.clone())`.
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<M, P>>;
+}
+
+/// Plug-in repair operator for ALNS.
+///
+/// A repair operator consumes the partial state produced by a destroy
+/// operator and returns a complete `(solution, score)` pair.
+///
+/// See [`DestroyOperator`] for the dyn-clone contract.
+pub trait RepairOperator<M: OptModel, P>: Send + Sync {
+    /// Apply the repair step and return a complete solution with its score.
+    fn repair(&self, model: &M, partial: P) -> (M::SolutionType, M::ScoreType);
+    /// Clone the operator into a `Box<dyn RepairOperator>`.
+    fn dyn_clone(&self) -> Box<dyn RepairOperator<M, P>>;
+}
+
+impl<M: OptModel, P> Clone for Box<dyn DestroyOperator<M, P>> {
+    fn clone(&self) -> Self {
+        self.dyn_clone()
+    }
+}
+
+impl<M: OptModel, P> Clone for Box<dyn RepairOperator<M, P>> {
+    fn clone(&self) -> Self {
+        self.dyn_clone()
+    }
+}
+
+/// Adaptive Large Neighborhood Search trial generator.
+///
+/// Holds destroy and repair operator pools together with their adaptive
+/// weights. Each call to [`TrialGenerator::generate_trial`] picks one
+/// destroy and one repair operator via independent roulette-wheel draws,
+/// applies them in sequence, and stores the indices so that
+/// [`TrialGenerator::feedback`] can credit the right operators.
+///
+/// `n_trials == 1` is the common usage for ALNS. When the search loop uses
+/// a larger `n_trials`, feedback is applied to the operator pair produced
+/// by the most recent `generate_trial` call (LIFO order) — typically only
+/// the best candidate in the iteration matters.
+pub struct AlnsTrialGenerator<M: OptModel, P> {
+    destroy_operators: Vec<Box<dyn DestroyOperator<M, P>>>,
+    destroy_stats: Vec<OperatorStats>,
+    repair_operators: Vec<Box<dyn RepairOperator<M, P>>>,
+    repair_stats: Vec<OperatorStats>,
+    /// Stack of destroy-operator indices pending feedback. One entry per
+    /// `generate_trial` call, popped in LIFO order by `feedback`.
+    selected_destroy: Vec<usize>,
+    /// Stack of repair-operator indices, parallel to
+    /// [`Self::selected_destroy`].
+    selected_repair: Vec<usize>,
+    /// Number of trials per segment — weights are recomputed whenever this
+    /// threshold is reached.
+    segment_size: usize,
+    /// Number of feedback calls since the last weight update.
+    trials_in_segment: usize,
+    /// Reaction factor `r` in `[0, 1]`. New weight blends the previous
+    /// weight and the segment performance as
+    /// `w_new = (1 - r) * w_old + r * (segment_score / usage_count)`.
+    reaction_factor: f64,
+    /// Reward table applied to destroy operators.
+    destroy_rewards: Rewards,
+    /// Reward table applied to repair operators.
+    repair_rewards: Rewards,
+    _phantom: PhantomData<(M, P)>,
+}
+
+impl<M: OptModel, P> AlnsTrialGenerator<M, P> {
+    /// Build a new ALNS generator from a pool of destroy and repair
+    /// operators. All operators start with weight `1.0`; reward tables
+    /// default to the classic Ropke & Pisinger scheme.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `destroy_operators` or `repair_operators` is empty — ALNS
+    /// cannot operate without at least one operator of each kind.
+    pub fn new(
+        destroy_operators: Vec<Box<dyn DestroyOperator<M, P>>>,
+        repair_operators: Vec<Box<dyn RepairOperator<M, P>>>,
+    ) -> Self {
+        assert!(
+            !destroy_operators.is_empty(),
+            "ALNS requires at least one destroy operator"
+        );
+        assert!(
+            !repair_operators.is_empty(),
+            "ALNS requires at least one repair operator"
+        );
+        let n_d = destroy_operators.len();
+        let n_r = repair_operators.len();
+        Self {
+            destroy_operators,
+            destroy_stats: (0..n_d).map(|_| OperatorStats::new(1.0)).collect(),
+            repair_operators,
+            repair_stats: (0..n_r).map(|_| OperatorStats::new(1.0)).collect(),
+            selected_destroy: Vec::new(),
+            selected_repair: Vec::new(),
+            segment_size: 100,
+            trials_in_segment: 0,
+            reaction_factor: 0.8,
+            destroy_rewards: Rewards::default(),
+            repair_rewards: Rewards::default(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Replace the segment size (number of trials between weight updates).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `segment_size == 0`.
+    pub fn with_segment_size(mut self, segment_size: usize) -> Self {
+        assert!(segment_size > 0, "segment_size must be positive");
+        self.segment_size = segment_size;
+        self
+    }
+
+    /// Replace the reaction factor `r` used when blending weights.
+    ///
+    /// Values outside `[0, 1]` are clamped into range.
+    pub fn with_reaction_factor(mut self, reaction_factor: f64) -> Self {
+        self.reaction_factor = reaction_factor.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Replace the reward table applied to destroy operators.
+    pub fn with_destroy_rewards(mut self, rewards: Rewards) -> Self {
+        self.destroy_rewards = rewards;
+        self
+    }
+
+    /// Replace the reward table applied to repair operators.
+    pub fn with_repair_rewards(mut self, rewards: Rewards) -> Self {
+        self.repair_rewards = rewards;
+        self
+    }
+
+    /// Replace the reward table applied to both destroy and repair operators.
+    pub fn with_rewards(mut self, rewards: Rewards) -> Self {
+        self.destroy_rewards = rewards;
+        self.repair_rewards = rewards;
+        self
+    }
+
+    /// Number of destroy operators registered with this generator.
+    pub fn n_destroy_operators(&self) -> usize {
+        self.destroy_operators.len()
+    }
+
+    /// Number of repair operators registered with this generator.
+    pub fn n_repair_operators(&self) -> usize {
+        self.repair_operators.len()
+    }
+
+    /// Current roulette-wheel weights for destroy operators.
+    pub fn destroy_weights(&self) -> Vec<f64> {
+        self.destroy_stats.iter().map(|s| s.weight).collect()
+    }
+
+    /// Current roulette-wheel weights for repair operators.
+    pub fn repair_weights(&self) -> Vec<f64> {
+        self.repair_stats.iter().map(|s| s.weight).collect()
+    }
+
+    /// Number of trials applied to each destroy operator since the last
+    /// weight update.
+    pub fn destroy_usage(&self) -> Vec<usize> {
+        self.destroy_stats.iter().map(|s| s.usage_count).collect()
+    }
+
+    /// Number of trials applied to each repair operator since the last
+    /// weight update.
+    pub fn repair_usage(&self) -> Vec<usize> {
+        self.repair_stats.iter().map(|s| s.usage_count).collect()
+    }
+
+    /// Accumulated reward for each destroy operator since the last weight
+    /// update.
+    pub fn destroy_scores(&self) -> Vec<f64> {
+        self.destroy_stats
+            .iter()
+            .map(|s| s.accumulated_score)
+            .collect()
+    }
+
+    /// Accumulated reward for each repair operator since the last weight
+    /// update.
+    pub fn repair_scores(&self) -> Vec<f64> {
+        self.repair_stats
+            .iter()
+            .map(|s| s.accumulated_score)
+            .collect()
+    }
+
+    /// Trials applied to operators during the current segment. Resets to
+    /// `0` after each weight update.
+    pub fn trials_in_segment(&self) -> usize {
+        self.trials_in_segment
+    }
+
+    /// Pick a destroy-operator index by roulette-wheel sampling.
+    fn select_destroy<R: rand::Rng>(&self, rng: &mut R) -> usize {
+        select_by_weight(&self.destroy_stats, rng)
+    }
+
+    /// Pick a repair-operator index by roulette-wheel sampling.
+    fn select_repair<R: rand::Rng>(&self, rng: &mut R) -> usize {
+        select_by_weight(&self.repair_stats, rng)
+    }
+}
+
+/// Roulette-wheel selection over an operator pool's weights.
+fn select_by_weight<R: rand::Rng>(stats: &[OperatorStats], rng: &mut R) -> usize {
+    let total: f64 = stats.iter().map(|s| s.weight).sum();
+    debug_assert!(total > 0.0, "operator weights must remain positive");
+    let target = rng.random::<f64>() * total;
+    let mut cumulative = 0.0;
+    for (idx, s) in stats.iter().enumerate() {
+        cumulative += s.weight;
+        if target < cumulative {
+            return idx;
+        }
+    }
+    stats.len() - 1
+}
+
+/// Recompute weights for one operator pool using the reaction-factor
+/// blending rule from Ropke & Pisinger (2006).
+fn apply_weight_update(stats: &mut [OperatorStats], reaction_factor: f64) {
+    for s in stats.iter_mut() {
+        let segment_avg = if s.usage_count > 0 {
+            s.accumulated_score / s.usage_count as f64
+        } else {
+            0.0
+        };
+        s.weight = reaction_factor.mul_add(segment_avg, (1.0 - reaction_factor) * s.weight);
+        // Avoid zero/negative weights so roulette-wheel sampling stays
+        // well-defined even when every operator did poorly.
+        if !s.weight.is_finite() || s.weight <= 0.0 {
+            s.weight = 1e-3;
+        }
+        s.accumulated_score = 0.0;
+        s.usage_count = 0;
+    }
+}
+
+impl<M: OptModel, P> Clone for AlnsTrialGenerator<M, P> {
+    fn clone(&self) -> Self {
+        Self {
+            destroy_operators: self.destroy_operators.clone(),
+            destroy_stats: self.destroy_stats.clone(),
+            repair_operators: self.repair_operators.clone(),
+            repair_stats: self.repair_stats.clone(),
+            selected_destroy: self.selected_destroy.clone(),
+            selected_repair: self.selected_repair.clone(),
+            segment_size: self.segment_size,
+            trials_in_segment: self.trials_in_segment,
+            reaction_factor: self.reaction_factor,
+            destroy_rewards: self.destroy_rewards,
+            repair_rewards: self.repair_rewards,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<M: OptModel, P> TrialGenerator<M> for AlnsTrialGenerator<M, P> {
+    fn generate_trial<R: rand::Rng>(
+        &mut self,
+        model: &M,
+        current_solution: M::SolutionType,
+        _current_score: M::ScoreType,
+        rng: &mut R,
+    ) -> (M::SolutionType, M::ScoreType) {
+        let d_idx = self.select_destroy(rng);
+        let r_idx = self.select_repair(rng);
+        self.selected_destroy.push(d_idx);
+        self.selected_repair.push(r_idx);
+
+        let partial = self.destroy_operators[d_idx].destroy(model, current_solution);
+        self.repair_operators[r_idx].repair(model, partial)
+    }
+
+    fn feedback(&mut self, outcome: TrialOutcome) {
+        // Credit the most recently picked operators and update weights at
+        // segment boundaries.
+        let d_idx = self
+            .selected_destroy
+            .pop()
+            .expect("feedback called more times than generate_trial");
+        let r_idx = self
+            .selected_repair
+            .pop()
+            .expect("feedback called more times than generate_trial");
+
+        let d_reward = self.destroy_rewards.reward_for(outcome);
+        let r_reward = self.repair_rewards.reward_for(outcome);
+
+        self.destroy_stats[d_idx].accumulated_score += d_reward;
+        self.destroy_stats[d_idx].usage_count += 1;
+        self.repair_stats[r_idx].accumulated_score += r_reward;
+        self.repair_stats[r_idx].usage_count += 1;
+
+        self.trials_in_segment += 1;
+        if self.trials_in_segment >= self.segment_size {
+            apply_weight_update(&mut self.destroy_stats, self.reaction_factor);
+            apply_weight_update(&mut self.repair_stats, self.reaction_factor);
+            self.trials_in_segment = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewards_lookup_matches_constructor() {
+        let r = Rewards::new(10.0, 5.0, 2.0, 0.5);
+        assert_eq!(r.reward_for(TrialOutcome::NewBest), 10.0);
+        assert_eq!(r.reward_for(TrialOutcome::Improved), 5.0);
+        assert_eq!(r.reward_for(TrialOutcome::Accepted), 2.0);
+        assert_eq!(r.reward_for(TrialOutcome::Rejected), 0.5);
+    }
+
+    #[test]
+    fn select_by_weight_skewed_distribution() {
+        let stats = vec![
+            OperatorStats {
+                weight: 0.0,
+                accumulated_score: 0.0,
+                usage_count: 0,
+            },
+            OperatorStats {
+                weight: 1.0,
+                accumulated_score: 0.0,
+                usage_count: 0,
+            },
+        ];
+        let mut rng = rand::rng();
+        let mut picks = [0usize, 0usize];
+        for _ in 0..1000 {
+            let idx = select_by_weight(&stats, &mut rng);
+            picks[idx] += 1;
+        }
+        // The first operator has weight 0 so should never be picked.
+        assert_eq!(picks[0], 0);
+        assert_eq!(picks[1], 1000);
+    }
+
+    #[test]
+    fn apply_weight_update_blends_with_segment_average() {
+        let mut stats = vec![OperatorStats {
+            weight: 1.0,
+            accumulated_score: 10.0,
+            usage_count: 2,
+        }];
+        apply_weight_update(&mut stats, 0.5);
+        // (1 - 0.5) * 1.0 + 0.5 * (10.0 / 2.0) = 0.5 + 2.5 = 3.0
+        assert!((stats[0].weight - 3.0).abs() < 1e-12);
+        // Bookkeeping is reset.
+        assert_eq!(stats[0].accumulated_score, 0.0);
+        assert_eq!(stats[0].usage_count, 0);
+    }
+
+    #[test]
+    fn apply_weight_update_clamps_non_positive_weights() {
+        let mut stats = vec![OperatorStats {
+            weight: 0.5,
+            accumulated_score: -100.0,
+            usage_count: 1,
+        }];
+        apply_weight_update(&mut stats, 1.0);
+        // Would be -100.0 without the floor — but the clamp keeps it positive.
+        assert!(stats[0].weight > 0.0);
+    }
+}

--- a/src/optim/alns.rs
+++ b/src/optim/alns.rs
@@ -32,17 +32,18 @@
 
 use std::marker::PhantomData;
 
-use rand::RngExt as _;
+use rand::{RngExt as _, rngs::StdRng};
 
 use super::search_loop::{TrialGenerator, TrialOutcome};
 use crate::OptModel;
 
 /// Per-outcome reward table for ALNS operator credit.
 ///
-/// Defaults follow the widely used Ropke & Pisinger scheme: a new global
-/// best is worth the most, an improvement over the current solution is
-/// rewarded less, accepting a non-improving solution gets a small reward,
-/// and a rejected trial contributes nothing.
+/// Defaults follow the classic Ropke & Pisinger scheme (33/9/13/0): a new
+/// global best is worth the most, an improvement over the current solution
+/// comes next, and an accepted non-improving trial still earns a reward —
+/// note the classic scheme rates an accepted move above a merely improving
+/// one — while a rejected trial contributes nothing.
 #[derive(Debug, Clone, Copy)]
 pub struct Rewards {
     /// Reward for a trial that produced a new global best.
@@ -81,7 +82,8 @@ impl Rewards {
 
 impl Default for Rewards {
     fn default() -> Self {
-        // Classic Ropke & Pisinger weights.
+        // Classic Ropke & Pisinger values (33/9/13/0). Note `accepted`
+        // intentionally exceeds `improved` in this scheme.
         Self {
             new_best: 33.0,
             improved: 9.0,
@@ -119,9 +121,11 @@ impl OperatorStats {
 /// were removed, a set of moves to undo, or anything the matching
 /// [`RepairOperator`] knows how to interpret.
 ///
-/// Implementors create their own RNG internally via [`rand::rng()`] (or any
-/// other source) so that the trait stays object-safe and operators can be
-/// stored as `Box<dyn DestroyOperator<_, _>>`.
+/// `solution` is borrowed so the loop can share it across rayon worker
+/// threads; clone what you need. `rng` is a per-trial fork supplied by the
+/// loop — use it for all randomness instead of creating your own, so runs
+/// stay reproducible. The concrete [`StdRng`] type keeps the trait
+/// object-safe so operators can be stored as `Box<dyn DestroyOperator<_, _>>`.
 ///
 /// Object-safety is preserved by providing a [`Self::dyn_clone`] method
 /// instead of adding [`Clone`] as a supertrait (which would force
@@ -130,7 +134,7 @@ impl OperatorStats {
 /// concrete type — see the example in `src/tests/test_alns.rs`.
 pub trait DestroyOperator<M: OptModel, P>: Send + Sync {
     /// Apply the destroy step and produce a partial state.
-    fn destroy(&self, model: &M, solution: M::SolutionType) -> P;
+    fn destroy(&self, model: &M, solution: &M::SolutionType, rng: &mut StdRng) -> P;
     /// Clone the operator into a `Box<dyn DestroyOperator>`. Implementors
     /// typically write `Box::new(self.clone())`.
     fn dyn_clone(&self) -> Box<dyn DestroyOperator<M, P>>;
@@ -139,12 +143,14 @@ pub trait DestroyOperator<M: OptModel, P>: Send + Sync {
 /// Plug-in repair operator for ALNS.
 ///
 /// A repair operator consumes the partial state produced by a destroy
-/// operator and returns a complete `(solution, score)` pair.
+/// operator and returns a complete `(solution, score)` pair. Like
+/// [`DestroyOperator`], it receives the loop's per-trial [`StdRng`] fork —
+/// use it for all randomness.
 ///
 /// See [`DestroyOperator`] for the dyn-clone contract.
 pub trait RepairOperator<M: OptModel, P>: Send + Sync {
     /// Apply the repair step and return a complete solution with its score.
-    fn repair(&self, model: &M, partial: P) -> (M::SolutionType, M::ScoreType);
+    fn repair(&self, model: &M, partial: P, rng: &mut StdRng) -> (M::SolutionType, M::ScoreType);
     /// Clone the operator into a `Box<dyn RepairOperator>`.
     fn dyn_clone(&self) -> Box<dyn RepairOperator<M, P>>;
 }
@@ -166,24 +172,20 @@ impl<M: OptModel, P> Clone for Box<dyn RepairOperator<M, P>> {
 /// Holds destroy and repair operator pools together with their adaptive
 /// weights. Each call to [`TrialGenerator::generate_trial`] picks one
 /// destroy and one repair operator via independent roulette-wheel draws,
-/// applies them in sequence, and stores the indices so that
-/// [`TrialGenerator::feedback`] can credit the right operators.
+/// applies them in sequence, and returns the chosen indices as the trial
+/// token so that [`TrialGenerator::feedback`] can credit the right
+/// operators.
 ///
-/// `n_trials == 1` is the common usage for ALNS. When the search loop uses
-/// a larger `n_trials`, feedback is applied to the operator pair produced
-/// by the most recent `generate_trial` call (LIFO order) — typically only
-/// the best candidate in the iteration matters.
+/// Generation takes `&self`, so the search loop can run `n_trials`
+/// candidates in parallel on rayon worker threads. Only the winning
+/// candidate is evaluated per iteration, so only the operator pair that
+/// produced the winner is credited (winner-takes-all); the remaining
+/// candidates are discarded without reward.
 pub struct AlnsTrialGenerator<M: OptModel, P> {
     destroy_operators: Vec<Box<dyn DestroyOperator<M, P>>>,
     destroy_stats: Vec<OperatorStats>,
     repair_operators: Vec<Box<dyn RepairOperator<M, P>>>,
     repair_stats: Vec<OperatorStats>,
-    /// Stack of destroy-operator indices pending feedback. One entry per
-    /// `generate_trial` call, popped in LIFO order by `feedback`.
-    selected_destroy: Vec<usize>,
-    /// Stack of repair-operator indices, parallel to
-    /// [`Self::selected_destroy`].
-    selected_repair: Vec<usize>,
     /// Number of trials per segment — weights are recomputed whenever this
     /// threshold is reached.
     segment_size: usize,
@@ -228,8 +230,6 @@ impl<M: OptModel, P> AlnsTrialGenerator<M, P> {
             destroy_stats: (0..n_d).map(|_| OperatorStats::new(1.0)).collect(),
             repair_operators,
             repair_stats: (0..n_r).map(|_| OperatorStats::new(1.0)).collect(),
-            selected_destroy: Vec::new(),
-            selected_repair: Vec::new(),
             segment_size: 100,
             trials_in_segment: 0,
             reaction_factor: 0.8,
@@ -342,6 +342,25 @@ impl<M: OptModel, P> AlnsTrialGenerator<M, P> {
     fn select_repair<R: rand::Rng>(&self, rng: &mut R) -> usize {
         select_by_weight(&self.repair_stats, rng)
     }
+
+    /// Credit one operator pair and advance the segment bookkeeping,
+    /// updating weights at segment boundaries.
+    fn credit(&mut self, d_idx: usize, r_idx: usize, outcome: TrialOutcome) {
+        let d_reward = self.destroy_rewards.reward_for(outcome);
+        let r_reward = self.repair_rewards.reward_for(outcome);
+
+        self.destroy_stats[d_idx].accumulated_score += d_reward;
+        self.destroy_stats[d_idx].usage_count += 1;
+        self.repair_stats[r_idx].accumulated_score += r_reward;
+        self.repair_stats[r_idx].usage_count += 1;
+
+        self.trials_in_segment += 1;
+        if self.trials_in_segment >= self.segment_size {
+            apply_weight_update(&mut self.destroy_stats, self.reaction_factor);
+            apply_weight_update(&mut self.repair_stats, self.reaction_factor);
+            self.trials_in_segment = 0;
+        }
+    }
 }
 
 /// Roulette-wheel selection over an operator pool's weights.
@@ -360,14 +379,15 @@ fn select_by_weight<R: rand::Rng>(stats: &[OperatorStats], rng: &mut R) -> usize
 }
 
 /// Recompute weights for one operator pool using the reaction-factor
-/// blending rule from Ropke & Pisinger (2006).
+/// blending rule from Ropke & Pisinger (2006). Operators unused during the
+/// segment keep their previous weight.
 fn apply_weight_update(stats: &mut [OperatorStats], reaction_factor: f64) {
     for s in stats.iter_mut() {
-        let segment_avg = if s.usage_count > 0 {
-            s.accumulated_score / s.usage_count as f64
-        } else {
-            0.0
-        };
+        if s.usage_count == 0 {
+            s.accumulated_score = 0.0;
+            continue;
+        }
+        let segment_avg = s.accumulated_score / s.usage_count as f64;
         s.weight = reaction_factor.mul_add(segment_avg, (1.0 - reaction_factor) * s.weight);
         // Avoid zero/negative weights so roulette-wheel sampling stays
         // well-defined even when every operator did poorly.
@@ -386,8 +406,6 @@ impl<M: OptModel, P> Clone for AlnsTrialGenerator<M, P> {
             destroy_stats: self.destroy_stats.clone(),
             repair_operators: self.repair_operators.clone(),
             repair_stats: self.repair_stats.clone(),
-            selected_destroy: self.selected_destroy.clone(),
-            selected_repair: self.selected_repair.clone(),
             segment_size: self.segment_size,
             trials_in_segment: self.trials_in_segment,
             reaction_factor: self.reaction_factor,
@@ -399,48 +417,26 @@ impl<M: OptModel, P> Clone for AlnsTrialGenerator<M, P> {
 }
 
 impl<M: OptModel, P> TrialGenerator<M> for AlnsTrialGenerator<M, P> {
-    fn generate_trial<R: rand::Rng>(
-        &mut self,
+    /// `(destroy_index, repair_index)` of the operators that produced the
+    /// trial.
+    type Token = (usize, usize);
+
+    fn generate_trial(
+        &self,
         model: &M,
-        current_solution: M::SolutionType,
+        current_solution: &M::SolutionType,
         _current_score: M::ScoreType,
-        rng: &mut R,
-    ) -> (M::SolutionType, M::ScoreType) {
+        rng: &mut StdRng,
+    ) -> (M::SolutionType, M::ScoreType, Self::Token) {
         let d_idx = self.select_destroy(rng);
         let r_idx = self.select_repair(rng);
-        self.selected_destroy.push(d_idx);
-        self.selected_repair.push(r_idx);
-
-        let partial = self.destroy_operators[d_idx].destroy(model, current_solution);
-        self.repair_operators[r_idx].repair(model, partial)
+        let partial = self.destroy_operators[d_idx].destroy(model, current_solution, rng);
+        let (solution, score) = self.repair_operators[r_idx].repair(model, partial, rng);
+        (solution, score, (d_idx, r_idx))
     }
 
-    fn feedback(&mut self, outcome: TrialOutcome) {
-        // Credit the most recently picked operators and update weights at
-        // segment boundaries.
-        let d_idx = self
-            .selected_destroy
-            .pop()
-            .expect("feedback called more times than generate_trial");
-        let r_idx = self
-            .selected_repair
-            .pop()
-            .expect("feedback called more times than generate_trial");
-
-        let d_reward = self.destroy_rewards.reward_for(outcome);
-        let r_reward = self.repair_rewards.reward_for(outcome);
-
-        self.destroy_stats[d_idx].accumulated_score += d_reward;
-        self.destroy_stats[d_idx].usage_count += 1;
-        self.repair_stats[r_idx].accumulated_score += r_reward;
-        self.repair_stats[r_idx].usage_count += 1;
-
-        self.trials_in_segment += 1;
-        if self.trials_in_segment >= self.segment_size {
-            apply_weight_update(&mut self.destroy_stats, self.reaction_factor);
-            apply_weight_update(&mut self.repair_stats, self.reaction_factor);
-            self.trials_in_segment = 0;
-        }
+    fn feedback(&mut self, token: Self::Token, outcome: TrialOutcome) {
+        self.credit(token.0, token.1, outcome);
     }
 }
 
@@ -507,5 +503,93 @@ mod tests {
         apply_weight_update(&mut stats, 1.0);
         // Would be -100.0 without the floor — but the clamp keeps it positive.
         assert!(stats[0].weight > 0.0);
+    }
+
+    #[test]
+    fn apply_weight_update_keeps_weight_for_unused_operators() {
+        let mut stats = vec![
+            OperatorStats {
+                weight: 2.5,
+                accumulated_score: 0.0,
+                usage_count: 0,
+            },
+            OperatorStats {
+                weight: 1.0,
+                accumulated_score: 10.0,
+                usage_count: 2,
+            },
+        ];
+        apply_weight_update(&mut stats, 0.5);
+        // Unused operator keeps its weight; used one blends toward its average.
+        assert!((stats[0].weight - 2.5).abs() < 1e-12);
+        assert!((stats[1].weight - 3.0).abs() < 1e-12);
+    }
+
+    // Minimal stub model so token-routed `feedback` can be tested deterministically.
+    #[derive(Clone)]
+    struct StubModel;
+
+    impl crate::OptModel for StubModel {
+        type SolutionType = ();
+        type TransitionType = ();
+        type ScoreType = i32;
+
+        fn generate_random_solution<R: rand::Rng>(
+            &self,
+            _rng: &mut R,
+        ) -> Result<(Self::SolutionType, Self::ScoreType), crate::LocalsearchError> {
+            Ok(((), 0))
+        }
+
+        fn generate_trial_solution<R: rand::Rng>(
+            &self,
+            current_solution: Self::SolutionType,
+            current_score: Self::ScoreType,
+            _rng: &mut R,
+        ) -> (Self::SolutionType, Self::TransitionType, Self::ScoreType) {
+            (current_solution, (), current_score)
+        }
+    }
+
+    #[derive(Clone)]
+    struct StubDestroy;
+
+    impl DestroyOperator<StubModel, ()> for StubDestroy {
+        fn destroy(&self, _model: &StubModel, _solution: &(), _rng: &mut StdRng) {}
+
+        fn dyn_clone(&self) -> Box<dyn DestroyOperator<StubModel, ()>> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct StubRepair;
+
+    impl RepairOperator<StubModel, ()> for StubRepair {
+        fn repair(&self, _model: &StubModel, _partial: (), _rng: &mut StdRng) -> ((), i32) {
+            ((), 0)
+        }
+
+        fn dyn_clone(&self) -> Box<dyn RepairOperator<StubModel, ()>> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[test]
+    fn feedback_credits_token_holder() {
+        let mut generator = AlnsTrialGenerator::<StubModel, ()>::new(
+            vec![Box::new(StubDestroy), Box::new(StubDestroy)],
+            vec![Box::new(StubRepair), Box::new(StubRepair)],
+        )
+        .with_segment_size(usize::MAX)
+        .with_rewards(Rewards::new(1.0, 0.0, 0.0, 0.0));
+        // The token — not recency — decides who is credited: tokens carry
+        // the operator pair, so the loop can generate trials in parallel
+        // and credit only the winner.
+        generator.feedback((1, 1), TrialOutcome::NewBest);
+        assert_eq!(generator.destroy_usage(), vec![0, 1]);
+        assert_eq!(generator.repair_usage(), vec![0, 1]);
+        assert_eq!(generator.destroy_scores(), vec![0.0, 1.0]);
+        assert_eq!(generator.repair_scores(), vec![0.0, 1.0]);
     }
 }

--- a/src/optim/generic.rs
+++ b/src/optim/generic.rs
@@ -1,39 +1,57 @@
 use std::marker::PhantomData;
 
-use super::{LocalSearchOptimizer, TransitionHandler, search_loop::LocalSearchLoop};
+use super::{
+    DefaultTrialGenerator, LocalSearchOptimizer, TransitionHandler,
+    search_loop::{LocalSearchLoop, TrialGenerator},
+};
 use crate::{Duration, OptModel, callback::OptCallbackFn};
 
-/// Generic local-search optimizer that owns a [`TransitionHandler`].
+/// Generic local-search optimizer that owns a [`TransitionHandler`] and,
+/// optionally, a [`TrialGenerator`].
 ///
-/// Wraps [`LocalSearchLoop`] (the trial/accept loop shared by every annealing
-/// variant) and exposes it through the [`LocalSearchOptimizer`] trait so it
-/// can be used wherever a concrete optimizer is expected.
+/// Wraps [`LocalSearchLoop`] (the trial/accept loop shared by every
+/// annealing variant) and exposes it through the [`LocalSearchOptimizer`]
+/// trait so it can be used wherever a concrete optimizer is expected.
 ///
 /// The stored handler is treated as a *blueprint*: each call to
 /// [`optimize`](LocalSearchOptimizer::optimize) clones it (via
 /// [`Clone`]) and lets the per-iteration
-/// [`TransitionHandler::update`] mutations run on the working copy. The stored
-/// handler is therefore left untouched across runs and can be reused
-/// indefinitely.
+/// [`TransitionHandler::update`] mutations run on the working copy. The
+/// stored handler is therefore left untouched across runs and can be
+/// reused indefinitely.
 ///
 /// Use this when you want to drive an arbitrary algorithm through the
-/// standard `LocalSearchOptimizer` interface. When you need full control over
-/// the handler's lifetime (e.g. to inspect its post-run state), reach for
-/// [`LocalSearchLoop`] directly.
-pub struct GenericLocalSearchOptimizer<ST, H> {
+/// standard `LocalSearchOptimizer` interface. When you need full control
+/// over the handler's lifetime (e.g. to inspect its post-run state), reach
+/// for [`LocalSearchLoop`] directly.
+///
+/// # Trial generation
+///
+/// By default the optimizer uses [`DefaultTrialGenerator`], which simply
+/// delegates to [`OptModel::generate_trial_solution`]. To plug in an
+/// adaptive scheme (such as ALNS), call
+/// [`Self::with_trial_generator`] with a custom generator. The generator
+/// must implement [`Clone`] because it is cloned for each `optimize`
+/// call, just like the handler.
+pub struct GenericLocalSearchOptimizer<ST, H, G = DefaultTrialGenerator> {
     patience: usize,
     n_trials: usize,
     return_iter: usize,
     handler: H,
+    generator: G,
     phantom: PhantomData<ST>,
 }
 
-impl<ST, H> GenericLocalSearchOptimizer<ST, H>
+impl<ST, H> GenericLocalSearchOptimizer<ST, H, DefaultTrialGenerator>
 where
     ST: Ord + Send + Sync + Copy,
     H: TransitionHandler<ST>,
 {
     /// Constructor of `GenericLocalSearchOptimizer`.
+    ///
+    /// Uses [`DefaultTrialGenerator`] for trial generation so existing
+    /// call sites keep their previous behavior. To switch to ALNS or any
+    /// other adaptive scheme, chain [`Self::with_trial_generator`].
     ///
     /// - `patience` : the optimizer will give up
     ///   if there is no improvement of the score after this number of iterations
@@ -46,21 +64,48 @@ where
             n_trials,
             return_iter,
             handler,
+            generator: DefaultTrialGenerator,
             phantom: PhantomData,
         }
     }
+}
 
+impl<ST, H, G> GenericLocalSearchOptimizer<ST, H, G>
+where
+    ST: Ord + Send + Sync + Copy,
+    H: TransitionHandler<ST>,
+{
     /// Borrow the stored handler blueprint.
     pub fn handler(&self) -> &H {
         &self.handler
     }
+
+    /// Borrow the stored trial generator.
+    pub fn generator(&self) -> &G {
+        &self.generator
+    }
+
+    /// Builder that swaps in a different [`TrialGenerator`]. The original
+    /// optimizer is consumed and a new optimizer is returned with the
+    /// supplied generator.
+    pub fn with_trial_generator<NG>(self, generator: NG) -> GenericLocalSearchOptimizer<ST, H, NG> {
+        GenericLocalSearchOptimizer {
+            patience: self.patience,
+            n_trials: self.n_trials,
+            return_iter: self.return_iter,
+            handler: self.handler,
+            generator,
+            phantom: PhantomData,
+        }
+    }
 }
 
-impl<M, H> LocalSearchOptimizer<M> for GenericLocalSearchOptimizer<M::ScoreType, H>
+impl<M, H, G> LocalSearchOptimizer<M> for GenericLocalSearchOptimizer<M::ScoreType, H, G>
 where
     M: OptModel,
     M::ScoreType: Ord + Send + Sync + Copy,
     H: TransitionHandler<M::ScoreType> + Clone,
+    G: TrialGenerator<M> + Clone,
 {
     fn optimize(
         &self,
@@ -72,9 +117,10 @@ where
         callback: &mut dyn OptCallbackFn<M::SolutionType, M::ScoreType>,
     ) -> (M::SolutionType, M::ScoreType) {
         let handler = self.handler.clone();
+        let generator = self.generator.clone();
         let loop_ =
             LocalSearchLoop::<M::ScoreType>::new(self.patience, self.n_trials, self.return_iter);
-        let (result, _) = loop_.step(
+        let (result, _, _) = loop_.step_with_generator(
             model,
             initial_solution,
             initial_score,
@@ -82,6 +128,7 @@ where
             time_limit,
             callback,
             handler,
+            generator,
         );
         (result.best_solution, result.best_score)
     }

--- a/src/optim/generic.rs
+++ b/src/optim/generic.rs
@@ -105,7 +105,7 @@ where
     M: OptModel,
     M::ScoreType: Ord + Send + Sync + Copy,
     H: TransitionHandler<M::ScoreType> + Clone,
-    G: TrialGenerator<M> + Clone,
+    G: TrialGenerator<M> + Clone + Sync,
 {
     fn optimize(
         &self,

--- a/src/optim/search_loop.rs
+++ b/src/optim/search_loop.rs
@@ -248,7 +248,7 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             //    evaluated and fed back (winner-takes-all).
             assert!(self.n_trials > 0, "n_trials must be at least 1");
             let seeds: Vec<u64> = (0..self.n_trials).map(|_| rng.random()).collect();
-            let mut candidates: Vec<(M::SolutionType, M::ScoreType, G::Token)> = seeds
+            let (trial_solution, trial_score, winner_token) = seeds
                 .into_par_iter()
                 .map(|seed| {
                     let mut local_rng = rand::rngs::StdRng::seed_from_u64(seed);
@@ -259,14 +259,8 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
                         &mut local_rng,
                     )
                 })
-                .collect();
-            let winner = candidates
-                .iter()
-                .enumerate()
-                .min_by_key(|(_, cand)| cand.1)
-                .map(|(idx, _)| idx)
+                .min_by_key(|(_, score, _)| *score)
                 .expect("n_trials must be at least 1");
-            let (trial_solution, trial_score, winner_token) = candidates.swap_remove(winner);
 
             // 4. Classify the trial outcome and apply best-score bookkeeping.
             //    `previous_best` is captured before any updates so that the

--- a/src/optim/search_loop.rs
+++ b/src/optim/search_loop.rs
@@ -31,14 +31,17 @@ pub struct StepResult<S, ST> {
 /// operators that produced the trial.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrialOutcome {
-    /// Trial produced a new global best solution and was accepted.
+    /// Trial produced a new global best solution. Classified independently
+    /// of acceptance: the global best is recorded before the acceptance
+    /// check, so a rejected trial that beat the best still earns this credit.
     NewBest,
     /// Trial improved over the current solution and was accepted, but did
     /// not improve the global best.
     Improved,
     /// Trial was accepted but did not improve the current solution.
     Accepted,
-    /// Trial was rejected by the acceptance criterion.
+    /// Trial was rejected by the acceptance criterion (and did not beat the
+    /// global best — see [`TrialOutcome::NewBest`]).
     Rejected,
 }
 
@@ -284,8 +287,11 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             acceptance_counter.enqueue(accepted);
 
             // 6. Tell the generator what happened so adaptive schemes can
-            //    update their internal state.
-            let outcome = if accepted && trial_score < previous_best {
+            //    update their internal state. `NewBest` is classified
+            //    independently of acceptance: the global best is recorded
+            //    before the acceptance check, so a rejected trial that
+            //    nonetheless beat the previous best still earns the credit.
+            let outcome = if trial_score < previous_best {
                 TrialOutcome::NewBest
             } else if accepted && trial_score < current_score {
                 TrialOutcome::Improved

--- a/src/optim/search_loop.rs
+++ b/src/optim/search_loop.rs
@@ -1,7 +1,6 @@
 use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 
 use rand::RngExt as _;
-use rayon::prelude::*;
 
 use super::transition::TransitionHandler;
 use crate::{
@@ -23,6 +22,75 @@ pub struct StepResult<S, ST> {
     pub last_score: ST,
     /// Acceptance counter for the step.
     pub acceptance_counter: AcceptanceCounter,
+}
+
+/// Outcome classification for an attempt at a new trial solution.
+///
+/// Adaptive generators (such as ALNS) use this classification to credit the
+/// operators that produced the trial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrialOutcome {
+    /// Trial produced a new global best solution and was accepted.
+    NewBest,
+    /// Trial improved over the current solution and was accepted, but did
+    /// not improve the global best.
+    Improved,
+    /// Trial was accepted but did not improve the current solution.
+    Accepted,
+    /// Trial was rejected by the acceptance criterion.
+    Rejected,
+}
+
+/// Pluggable trial-generation abstraction that decouples neighborhood
+/// generation from the accept/reject loop.
+///
+/// A generator produces a single candidate solution and its score from the
+/// current solution and score, then receives a [`TrialOutcome`] via
+/// [`TrialGenerator::feedback`] after the loop has decided what to do with
+/// the trial. Adaptive generators (e.g. ALNS) use that feedback to update
+/// their internal state — operator weights, scores, or anything else.
+///
+/// The default behavior of [`OptModel::generate_trial_solution`] is
+/// recovered by [`DefaultTrialGenerator`], so existing optimizers keep
+/// their previous semantics.
+pub trait TrialGenerator<M: OptModel> {
+    /// Generate a single trial solution and its score from the current one.
+    fn generate_trial<R: rand::Rng>(
+        &mut self,
+        model: &M,
+        current_solution: M::SolutionType,
+        current_score: M::ScoreType,
+        rng: &mut R,
+    ) -> (M::SolutionType, M::ScoreType);
+
+    /// Notify the generator about the outcome of the most recently produced
+    /// trial. Generators without adaptive state can ignore this call.
+    fn feedback(&mut self, outcome: TrialOutcome);
+}
+
+/// Default trial generator that simply delegates to
+/// [`OptModel::generate_trial_solution`].
+///
+/// This keeps the historical behavior of [`LocalSearchLoop::step`]: every
+/// iteration's `n_trials` candidates come straight from the model's own
+/// neighborhood generator and `feedback` is a no-op.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultTrialGenerator;
+
+impl<M: OptModel> TrialGenerator<M> for DefaultTrialGenerator {
+    fn generate_trial<R: rand::Rng>(
+        &mut self,
+        model: &M,
+        current_solution: M::SolutionType,
+        current_score: M::ScoreType,
+        rng: &mut R,
+    ) -> (M::SolutionType, M::ScoreType) {
+        let (solution, _transition, score) =
+            model.generate_trial_solution(current_solution, current_score, rng);
+        (solution, score)
+    }
+
+    fn feedback(&mut self, _outcome: TrialOutcome) {}
 }
 
 /// Inner trial-and-accept loop shared by every local-search optimizer.
@@ -66,7 +134,9 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
     /// with the supplied handler.
     ///
     /// Returns the [`StepResult`] alongside the (possibly mutated) handler so
-    /// per-iteration state survives the call.
+    /// per-iteration state survives the call. Trial generation goes through the
+    /// built-in [`DefaultTrialGenerator`]; pass a custom generator via
+    /// [`Self::step_with_generator`] to use ALNS or any other adaptive scheme.
     #[allow(clippy::too_many_arguments)]
     pub fn step<M, H>(
         &self,
@@ -76,11 +146,53 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
         n_iter: usize,
         time_limit: Duration,
         callback: &mut dyn OptCallbackFn<M::SolutionType, M::ScoreType>,
-        mut handler: H,
+        handler: H,
     ) -> (StepResult<M::SolutionType, M::ScoreType>, H)
     where
         M: OptModel<ScoreType = ST>,
         H: TransitionHandler<ST>,
+    {
+        let (result, handler, _generator) = self.step_with_generator(
+            model,
+            initial_solution,
+            initial_score,
+            n_iter,
+            time_limit,
+            callback,
+            handler,
+            DefaultTrialGenerator,
+        );
+        (result, handler)
+    }
+
+    /// Perform one optimization step that drives trial generation through a
+    /// caller-supplied [`TrialGenerator`].
+    ///
+    /// The generator is invoked `n_trials` times per iteration, each call
+    /// produces one candidate, and the best candidate is fed through the
+    /// acceptance machinery. After the trial's outcome is known, the generator
+    /// receives a [`TrialOutcome`] via [`TrialGenerator::feedback`] so adaptive
+    /// schemes (ALNS, hyper-heuristics, …) can update their internal state.
+    ///
+    /// Returns the [`StepResult`], the (possibly mutated) handler, and the
+    /// (possibly mutated) generator — so callers can inspect or reuse their
+    /// adapted state after the step.
+    #[allow(clippy::too_many_arguments)]
+    pub fn step_with_generator<M, H, G>(
+        &self,
+        model: &M,
+        initial_solution: M::SolutionType,
+        initial_score: M::ScoreType,
+        n_iter: usize,
+        time_limit: Duration,
+        callback: &mut dyn OptCallbackFn<M::SolutionType, M::ScoreType>,
+        handler: H,
+        generator: G,
+    ) -> (StepResult<M::SolutionType, M::ScoreType>, H, G)
+    where
+        M: OptModel<ScoreType = ST>,
+        H: TransitionHandler<ST>,
+        G: TrialGenerator<M>,
     {
         let start_time = Instant::now();
         let mut rng = rand::rng();
@@ -92,6 +204,8 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
         // Separate stagnation counters: one for triggering a return to best, one for early stopping (patience)
         let mut return_stagnation_counter = 0;
         let mut patience_stagnation_counter = 0;
+        let mut handler = handler;
+        let mut generator = generator;
 
         for it in 0..n_iter {
             // 1. Update time and iteration counters
@@ -109,21 +223,26 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             };
             handler.update(&ctx);
 
+            // 3. Generate `n_trials` candidates through the supplied generator
+            //    and pick the best-scoring one.
             let (trial_solution, trial_score) = (0..self.n_trials)
-                .into_par_iter()
                 .map(|_| {
-                    let mut rng = rand::rng();
-                    let (solution, _, score) = model.generate_trial_solution(
+                    let mut local_rng = rand::rng();
+                    generator.generate_trial(
+                        model,
                         current_solution.clone(),
                         current_score,
-                        &mut rng,
-                    );
-                    (solution, score)
+                        &mut local_rng,
+                    )
                 })
                 .min_by_key(|(_, score)| *score)
-                .unwrap();
+                .expect("n_trials must be at least 1");
 
-            // 3. Update best solution and score
+            // 4. Classify the trial outcome and apply best-score bookkeeping.
+            //    `previous_best` is captured before any updates so that the
+            //    "new best" credit is given to the operators that actually
+            //    produced the new global best.
+            let previous_best = best_score;
             if trial_score < best_score {
                 best_solution.replace(trial_solution.clone());
                 best_score = trial_score;
@@ -134,32 +253,44 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
                 patience_stagnation_counter += 1;
             }
 
-            // 4. Update accepted counter and transitions
+            // 5. Acceptance.
             let p = handler.evaluate(current_score, trial_score);
             let r: f64 = rng.random();
             let accepted = p > r;
-
             acceptance_counter.enqueue(accepted);
 
-            // 5. Update current solution and score
+            // 6. Tell the generator what happened so adaptive schemes can
+            //    update their internal state.
+            let outcome = if accepted && trial_score < previous_best {
+                TrialOutcome::NewBest
+            } else if accepted && trial_score < current_score {
+                TrialOutcome::Improved
+            } else if accepted {
+                TrialOutcome::Accepted
+            } else {
+                TrialOutcome::Rejected
+            };
+            generator.feedback(outcome);
+
+            // 7. Update current solution and score.
             if accepted {
                 current_solution = trial_solution;
                 current_score = trial_score;
             }
 
-            // 6. Check and handle return to best
+            // 8. Check and handle return to best.
             if return_stagnation_counter == self.return_iter {
                 current_solution = best_solution.borrow().clone();
                 current_score = best_score;
                 return_stagnation_counter = 0;
             }
 
-            // 7. Check patience
+            // 9. Check patience.
             if patience_stagnation_counter == self.patience {
                 break;
             }
 
-            // 8. Invoke callback
+            // 10. Invoke callback.
             let progress = OptProgress::new(
                 it,
                 acceptance_counter.acceptance_ratio(),
@@ -177,6 +308,6 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             last_score: current_score,
             acceptance_counter,
         };
-        (result, handler)
+        (result, handler, generator)
     }
 }

--- a/src/optim/search_loop.rs
+++ b/src/optim/search_loop.rs
@@ -140,9 +140,15 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
     ///
     /// - `patience` : the loop will give up
     ///   if there is no improvement of the score after this number of iterations
-    /// - `n_trials` : number of trial solutions to generate and evaluate at each iteration
+    /// - `n_trials` : number of trial solutions to generate and evaluate at each iteration; must be at least 1
     /// - `return_iter` : returns to the current best solution if there is no improvement after this number of iterations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n_trials == 0` — every iteration needs at least one
+    /// candidate for the best-of-`n_trials` selection to be well-defined.
     pub fn new(patience: usize, n_trials: usize, return_iter: usize) -> Self {
+        assert!(n_trials > 0, "n_trials must be at least 1");
         Self {
             patience,
             n_trials,
@@ -248,8 +254,9 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             //    and keep the best-scoring one. Generation runs in parallel
             //    via rayon; each trial draws from a per-trial RNG fork seeded
             //    sequentially, so runs stay reproducible. Only the winner is
-            //    evaluated and fed back (winner-takes-all).
-            assert!(self.n_trials > 0, "n_trials must be at least 1");
+            //    evaluated and fed back (winner-takes-all). `n_trials >= 1`
+            //    is guaranteed by `LocalSearchLoop::new`, so `seeds` is never
+            //    empty.
             let seeds: Vec<u64> = (0..self.n_trials).map(|_| rng.random()).collect();
             let (trial_solution, trial_score, winner_token) = seeds
                 .into_par_iter()
@@ -263,7 +270,7 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
                     )
                 })
                 .min_by_key(|(_, score, _)| *score)
-                .expect("n_trials must be at least 1");
+                .expect("seeds is non-empty because LocalSearchLoop::new asserts n_trials >= 1");
 
             // 4. Classify the trial outcome and apply best-score bookkeeping.
             //    `previous_best` is captured before any updates so that the

--- a/src/optim/search_loop.rs
+++ b/src/optim/search_loop.rs
@@ -1,6 +1,7 @@
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use std::marker::PhantomData;
 
-use rand::RngExt as _;
+use rand::{RngExt as _, SeedableRng as _};
+use rayon::prelude::*;
 
 use super::transition::TransitionHandler;
 use crate::{
@@ -44,28 +45,43 @@ pub enum TrialOutcome {
 /// Pluggable trial-generation abstraction that decouples neighborhood
 /// generation from the accept/reject loop.
 ///
-/// A generator produces a single candidate solution and its score from the
-/// current solution and score, then receives a [`TrialOutcome`] via
+/// A generator produces candidate solutions from the current one, then
+/// receives a [`TrialOutcome`] for the winning candidate via
 /// [`TrialGenerator::feedback`] after the loop has decided what to do with
-/// the trial. Adaptive generators (e.g. ALNS) use that feedback to update
-/// their internal state — operator weights, scores, or anything else.
+/// it. Adaptive generators (e.g. ALNS) use that feedback to update their
+/// internal state — operator weights, scores, or anything else.
+///
+/// [`TrialGenerator::generate_trial`] takes `&self`, so the search loop can
+/// invoke it from multiple rayon worker threads in parallel. The returned
+/// [`TrialGenerator::Token`] identifies which operators produced the trial;
+/// the loop hands the winner's token back to [`TrialGenerator::feedback`]
+/// (winner-takes-all) while losers are discarded without reward.
 ///
 /// The default behavior of [`OptModel::generate_trial_solution`] is
 /// recovered by [`DefaultTrialGenerator`], so existing optimizers keep
 /// their previous semantics.
 pub trait TrialGenerator<M: OptModel> {
-    /// Generate a single trial solution and its score from the current one.
-    fn generate_trial<R: rand::Rng>(
-        &mut self,
-        model: &M,
-        current_solution: M::SolutionType,
-        current_score: M::ScoreType,
-        rng: &mut R,
-    ) -> (M::SolutionType, M::ScoreType);
+    /// Identifies the operators that produced a trial. The loop keeps each
+    /// candidate's token and hands only the winner's token to
+    /// [`TrialGenerator::feedback`]. Must be `Send` so candidates can be
+    /// generated on rayon worker threads.
+    type Token: Send;
 
-    /// Notify the generator about the outcome of the most recently produced
-    /// trial. Generators without adaptive state can ignore this call.
-    fn feedback(&mut self, outcome: TrialOutcome);
+    /// Generate a single trial solution, its score, and its token from the
+    /// current solution. Called concurrently from rayon worker threads —
+    /// implementations must be `Sync` and use only the supplied `rng`
+    /// (a per-trial fork) for randomness.
+    fn generate_trial(
+        &self,
+        model: &M,
+        current_solution: &M::SolutionType,
+        current_score: M::ScoreType,
+        rng: &mut rand::rngs::StdRng,
+    ) -> (M::SolutionType, M::ScoreType, Self::Token);
+
+    /// Notify the generator about the outcome of the winning trial.
+    /// Generators without adaptive state can ignore this call.
+    fn feedback(&mut self, token: Self::Token, outcome: TrialOutcome);
 }
 
 /// Default trial generator that simply delegates to
@@ -78,19 +94,21 @@ pub trait TrialGenerator<M: OptModel> {
 pub struct DefaultTrialGenerator;
 
 impl<M: OptModel> TrialGenerator<M> for DefaultTrialGenerator {
-    fn generate_trial<R: rand::Rng>(
-        &mut self,
+    type Token = ();
+
+    fn generate_trial(
+        &self,
         model: &M,
-        current_solution: M::SolutionType,
+        current_solution: &M::SolutionType,
         current_score: M::ScoreType,
-        rng: &mut R,
-    ) -> (M::SolutionType, M::ScoreType) {
+        rng: &mut rand::rngs::StdRng,
+    ) -> (M::SolutionType, M::ScoreType, Self::Token) {
         let (solution, _transition, score) =
-            model.generate_trial_solution(current_solution, current_score, rng);
-        (solution, score)
+            model.generate_trial_solution(current_solution.clone(), current_score, rng);
+        (solution, score, ())
     }
 
-    fn feedback(&mut self, _outcome: TrialOutcome) {}
+    fn feedback(&mut self, _token: Self::Token, _outcome: TrialOutcome) {}
 }
 
 /// Inner trial-and-accept loop shared by every local-search optimizer.
@@ -192,13 +210,13 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
     where
         M: OptModel<ScoreType = ST>,
         H: TransitionHandler<ST>,
-        G: TrialGenerator<M>,
+        G: TrialGenerator<M> + Sync,
     {
         let start_time = Instant::now();
         let mut rng = rand::rng();
         let mut current_solution = initial_solution;
         let mut current_score = initial_score;
-        let best_solution = Rc::new(RefCell::new(current_solution.clone()));
+        let mut best_solution = current_solution.clone();
         let mut best_score = current_score;
         let mut acceptance_counter = AcceptanceCounter::new(100);
         // Separate stagnation counters: one for triggering a return to best, one for early stopping (patience)
@@ -224,19 +242,31 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             handler.update(&ctx);
 
             // 3. Generate `n_trials` candidates through the supplied generator
-            //    and pick the best-scoring one.
-            let (trial_solution, trial_score) = (0..self.n_trials)
-                .map(|_| {
-                    let mut local_rng = rand::rng();
+            //    and keep the best-scoring one. Generation runs in parallel
+            //    via rayon; each trial draws from a per-trial RNG fork seeded
+            //    sequentially, so runs stay reproducible. Only the winner is
+            //    evaluated and fed back (winner-takes-all).
+            assert!(self.n_trials > 0, "n_trials must be at least 1");
+            let seeds: Vec<u64> = (0..self.n_trials).map(|_| rng.random()).collect();
+            let mut candidates: Vec<(M::SolutionType, M::ScoreType, G::Token)> = seeds
+                .into_par_iter()
+                .map(|seed| {
+                    let mut local_rng = rand::rngs::StdRng::seed_from_u64(seed);
                     generator.generate_trial(
                         model,
-                        current_solution.clone(),
+                        &current_solution,
                         current_score,
                         &mut local_rng,
                     )
                 })
-                .min_by_key(|(_, score)| *score)
+                .collect();
+            let winner = candidates
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, cand)| cand.1)
+                .map(|(idx, _)| idx)
                 .expect("n_trials must be at least 1");
+            let (trial_solution, trial_score, winner_token) = candidates.swap_remove(winner);
 
             // 4. Classify the trial outcome and apply best-score bookkeeping.
             //    `previous_best` is captured before any updates so that the
@@ -244,7 +274,7 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             //    produced the new global best.
             let previous_best = best_score;
             if trial_score < best_score {
-                best_solution.replace(trial_solution.clone());
+                best_solution = trial_solution.clone();
                 best_score = trial_score;
                 return_stagnation_counter = 0;
                 patience_stagnation_counter = 0;
@@ -270,7 +300,7 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             } else {
                 TrialOutcome::Rejected
             };
-            generator.feedback(outcome);
+            generator.feedback(winner_token, outcome);
 
             // 7. Update current solution and score.
             if accepted {
@@ -280,7 +310,7 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
 
             // 8. Check and handle return to best.
             if return_stagnation_counter == self.return_iter {
-                current_solution = best_solution.borrow().clone();
+                current_solution = best_solution.clone();
                 current_score = best_score;
                 return_stagnation_counter = 0;
             }
@@ -294,13 +324,12 @@ impl<ST: Ord + Sync + Send + Copy> LocalSearchLoop<ST> {
             let progress = OptProgress::new(
                 it,
                 acceptance_counter.acceptance_ratio(),
-                best_solution.clone(),
+                std::rc::Rc::new(std::cell::RefCell::new(best_solution.clone())),
                 best_score,
             );
             callback(progress);
         }
 
-        let best_solution = (*best_solution.borrow()).clone();
         let result = StepResult {
             best_solution,
             best_score,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,6 +59,7 @@ impl OptModel for QuadraticModel {
 }
 
 mod test_adaptive_annealing;
+mod test_alns;
 mod test_epsilon_greedy;
 mod test_great_deluge;
 mod test_hill_climbing;

--- a/src/tests/test_alns.rs
+++ b/src/tests/test_alns.rs
@@ -613,3 +613,10 @@ fn rejected_trial_beating_best_reports_new_best() {
         Some(TrialOutcome::NewBest)
     );
 }
+
+#[test]
+#[should_panic(expected = "n_trials must be at least 1")]
+fn local_search_loop_rejects_zero_trials() {
+    // Fail fast at construction instead of on the first iteration.
+    let _: LocalSearchLoop<NotNan<f64>> = LocalSearchLoop::new(10, 0, usize::MAX);
+}

--- a/src/tests/test_alns.rs
+++ b/src/tests/test_alns.rs
@@ -15,7 +15,7 @@ use crate::{
     optim::{
         AlnsTrialGenerator, DefaultTrialGenerator, DestroyOperator, EpsilonGreedy,
         GenericLocalSearchOptimizer, LocalSearchLoop, LocalSearchOptimizer, RepairOperator,
-        TrialGenerator, TrialOutcome,
+        TransitionHandler, TrialGenerator, TrialOutcome, UpdateCtx,
     },
 };
 
@@ -536,4 +536,80 @@ fn alns_with_multiple_trials_credits_only_winner_per_iteration() {
     let total_repair_usage: usize = returned.repair_usage().iter().sum();
     assert_eq!(total_destroy_usage, 10);
     assert_eq!(total_repair_usage, 10);
+}
+
+// ---------------------------------------------------------------------------
+// A trial that beats the global best is credited `NewBest` even when the
+// acceptance handler rejects it (best bookkeeping runs before acceptance).
+// ---------------------------------------------------------------------------
+
+/// Handler that always rejects. Deliberately violates the
+/// improving-transitions-return-1.0 contract so classification of rejected
+/// trials can be exercised.
+struct AlwaysReject;
+
+impl TransitionHandler<NotNan<f64>> for AlwaysReject {
+    fn update(&mut self, _ctx: &UpdateCtx<'_, NotNan<f64>>) {}
+
+    fn evaluate(&self, _current: NotNan<f64>, _trial: NotNan<f64>) -> f64 {
+        0.0
+    }
+}
+
+/// Generator whose every trial strictly improves on every previous one
+/// (score decreases with each call), recording the outcome it was last
+/// credited with. Deriving the score from the call count — not from
+/// `current_score` — keeps trials improving even when the handler rejects
+/// every one.
+#[derive(Default)]
+struct ImprovingGenerator {
+    calls: AtomicUsize,
+    last_outcome: Mutex<Option<TrialOutcome>>,
+}
+
+impl TrialGenerator<QuadraticModel> for ImprovingGenerator {
+    type Token = ();
+
+    fn generate_trial(
+        &self,
+        _model: &QuadraticModel,
+        current_solution: &Vec<f64>,
+        _current_score: NotNan<f64>,
+        _rng: &mut StdRng,
+    ) -> (Vec<f64>, NotNan<f64>, Self::Token) {
+        let calls = self.calls.fetch_add(1, Ordering::Relaxed) as f64;
+        let next = NotNan::new(-calls).expect("finite test score");
+        (current_solution.clone(), next, ())
+    }
+
+    fn feedback(&mut self, _token: Self::Token, outcome: TrialOutcome) {
+        *self.last_outcome.lock().expect("mutex poisoned") = Some(outcome);
+    }
+}
+
+#[test]
+fn rejected_trial_beating_best_reports_new_best() {
+    let model = QuadraticModel::new(1, vec![0.0], (-1.0, 1.0));
+    let opt = LocalSearchLoop::new(10, 1, usize::MAX);
+    let handler = AlwaysReject;
+    let mut cb = |_p| {};
+    let (result, _, generator) = opt.step_with_generator(
+        &model,
+        vec![0.5],
+        NotNan::new(0.25).unwrap(),
+        5,
+        Duration::from_secs(1),
+        &mut cb,
+        handler,
+        ImprovingGenerator::default(),
+    );
+    // Every trial strictly improves, so the recorded global best keeps
+    // dropping even though the handler rejects every single one.
+    assert!(result.best_score.into_inner() < 0.25);
+    // The generator must be credited `NewBest` — not `Rejected` — for a
+    // trial that produced the recorded global best.
+    assert_eq!(
+        *generator.last_outcome.lock().expect("mutex poisoned"),
+        Some(TrialOutcome::NewBest)
+    );
 }

--- a/src/tests/test_alns.rs
+++ b/src/tests/test_alns.rs
@@ -1,7 +1,13 @@
-use std::time::Duration;
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use ordered_float::NotNan;
-use rand::{RngExt as _, distr::Uniform, prelude::Distribution};
+use rand::{RngExt as _, SeedableRng as _, distr::Uniform, prelude::Distribution, rngs::StdRng};
 
 use super::QuadraticModel;
 use crate::{
@@ -79,8 +85,13 @@ impl OptModel for SumModel {
 struct DestroyFirstHalf;
 
 impl DestroyOperator<SumModel, PartialSolution> for DestroyFirstHalf {
-    fn destroy(&self, _model: &SumModel, solution: Vec<usize>) -> PartialSolution {
-        let mut partial: PartialSolution = solution.into_iter().map(Some).collect();
+    fn destroy(
+        &self,
+        _model: &SumModel,
+        solution: &Vec<usize>,
+        _rng: &mut StdRng,
+    ) -> PartialSolution {
+        let mut partial: PartialSolution = solution.iter().copied().map(Some).collect();
         let half = partial.len() / 2;
         for v in partial.iter_mut().take(half) {
             *v = None;
@@ -98,8 +109,13 @@ impl DestroyOperator<SumModel, PartialSolution> for DestroyFirstHalf {
 struct DestroySecondHalf;
 
 impl DestroyOperator<SumModel, PartialSolution> for DestroySecondHalf {
-    fn destroy(&self, _model: &SumModel, solution: Vec<usize>) -> PartialSolution {
-        let mut partial: PartialSolution = solution.into_iter().map(Some).collect();
+    fn destroy(
+        &self,
+        _model: &SumModel,
+        solution: &Vec<usize>,
+        _rng: &mut StdRng,
+    ) -> PartialSolution {
+        let mut partial: PartialSolution = solution.iter().copied().map(Some).collect();
         let half = partial.len() / 2;
         for v in partial.iter_mut().skip(half) {
             *v = None;
@@ -120,13 +136,17 @@ struct RandomRepair {
 }
 
 impl RepairOperator<SumModel, PartialSolution> for RandomRepair {
-    fn repair(&self, model: &SumModel, mut partial: PartialSolution) -> (Vec<usize>, NotNan<f64>) {
-        let mut rng = rand::rng();
+    fn repair(
+        &self,
+        model: &SumModel,
+        mut partial: PartialSolution,
+        rng: &mut StdRng,
+    ) -> (Vec<usize>, NotNan<f64>) {
         let dist = Uniform::new(self.value_range.0, self.value_range.1)
             .expect("value range must be valid");
         for slot in partial.iter_mut() {
             if slot.is_none() {
-                *slot = Some(dist.sample(&mut rng));
+                *slot = Some(dist.sample(rng));
             }
         }
         let solution = partial
@@ -185,33 +205,37 @@ fn default_step_matches_legacy_behavior() {
 // Custom generator is invoked through `step_with_generator`.
 // ---------------------------------------------------------------------------
 
+// Atomics + mutex keep the generator `Sync` so the loop can invoke it from
+// rayon worker threads.
 #[derive(Default)]
 struct CountingGenerator {
-    generate_calls: usize,
-    feedback_calls: usize,
-    last_outcome: Option<TrialOutcome>,
+    generate_calls: AtomicUsize,
+    feedback_calls: AtomicUsize,
+    last_outcome: Mutex<Option<TrialOutcome>>,
 }
 
 impl TrialGenerator<QuadraticModel> for CountingGenerator {
-    fn generate_trial<R: rand::Rng>(
-        &mut self,
+    type Token = ();
+
+    fn generate_trial(
+        &self,
         _model: &QuadraticModel,
-        current_solution: Vec<f64>,
+        current_solution: &Vec<f64>,
         current_score: NotNan<f64>,
-        _rng: &mut R,
-    ) -> (Vec<f64>, NotNan<f64>) {
-        self.generate_calls += 1;
+        _rng: &mut StdRng,
+    ) -> (Vec<f64>, NotNan<f64>, Self::Token) {
+        self.generate_calls.fetch_add(1, Ordering::Relaxed);
         // Nudge one coordinate; the loop still applies its acceptance logic.
-        let mut next = current_solution;
+        let mut next = current_solution.clone();
         if !next.is_empty() {
             next[0] += 0.1;
         }
-        (next, current_score)
+        (next, current_score, ())
     }
 
-    fn feedback(&mut self, outcome: TrialOutcome) {
-        self.feedback_calls += 1;
-        self.last_outcome = Some(outcome);
+    fn feedback(&mut self, _token: Self::Token, outcome: TrialOutcome) {
+        self.feedback_calls.fetch_add(1, Ordering::Relaxed);
+        *self.last_outcome.lock().expect("mutex poisoned") = Some(outcome);
     }
 }
 
@@ -233,9 +257,15 @@ fn custom_generator_is_invoked_through_step_with_generator() {
         generator,
     );
     // n_iter iterations × n_trials per iteration.
-    assert_eq!(returned.generate_calls, 5);
-    assert_eq!(returned.feedback_calls, 5);
-    assert!(returned.last_outcome.is_some());
+    assert_eq!(returned.generate_calls.load(Ordering::Relaxed), 5);
+    assert_eq!(returned.feedback_calls.load(Ordering::Relaxed), 5);
+    assert!(
+        returned
+            .last_outcome
+            .lock()
+            .expect("mutex poisoned")
+            .is_some()
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -267,21 +297,16 @@ fn alns_destroy_operator_selection_respects_weights() {
     let model = SumModel::new(4, (0, 100));
     let mut total_destroy_picks = [0usize, 0usize];
     let mut total_repair_picks = [0usize; 1];
-    for _ in 0..2000 {
+    for i in 0..2000 {
         let mut local = build_alns().with_segment_size(usize::MAX);
-        let mut rng = rand::rng();
-        let (_solution, _score) =
+        let mut rng = StdRng::seed_from_u64(42 + i);
+        let solution = vec![1, 2, 3, 4];
+        let (_solution, _score, token) =
             <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
-                &mut local,
-                &model,
-                vec![1, 2, 3, 4],
-                NotNan::new(10.0).unwrap(),
-                &mut rng,
+                &local, &model, &solution, NotNan::new(10.0).unwrap(), &mut rng,
             );
-        // Drain the stacks via feedback (we don't care about the outcome here).
-        local.feedback(TrialOutcome::Rejected);
-        // The destroy/repair stack should always have exactly one selection
-        // for each generate_trial call when n_trials == 1.
+        // Credit the trial via its token (we don't care about the outcome here).
+        local.feedback(token, TrialOutcome::Rejected);
         total_destroy_picks[0] += local.destroy_usage()[0];
         total_destroy_picks[1] += local.destroy_usage()[1];
         total_repair_picks[0] += local.repair_usage()[0];
@@ -339,11 +364,14 @@ fn alns_feedback_credits_rewards_to_selected_operators() {
         TrialOutcome::Accepted,
         TrialOutcome::Rejected,
     ] {
-        let mut local_rng = rand::rng();
-        let _ = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
-            &mut generator,
+        let mut local_rng = StdRng::seed_from_u64(7);
+        let solution = vec![1, 2, 3, 4];
+        let (_, _, token) = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<
+            SumModel,
+        >>::generate_trial(
+            &generator,
             &model,
-            vec![1, 2, 3, 4],
+            &solution,
             NotNan::new(10.0).unwrap(),
             &mut local_rng,
         );
@@ -353,7 +381,7 @@ fn alns_feedback_credits_rewards_to_selected_operators() {
             TrialOutcome::Accepted => 2.0,
             TrialOutcome::Rejected => 0.0,
         };
-        generator.feedback(outcome);
+        generator.feedback(token, outcome);
         // After this feedback, *some* destroy and *some* repair operator was
         // credited. Verify usage incremented and the aggregate reward is
         // accumulated correctly across all operators.
@@ -393,16 +421,19 @@ fn alns_updates_weights_at_segment_boundaries() {
     // Run 3 trials with reward 9 (Improved) each. With segment_size=3 and
     // reaction_factor=0.5, after the third feedback the weights are blended
     // with the segment average.
-    for _ in 0..3 {
-        let mut rng = rand::rng();
-        let _ = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
-            &mut generator,
+    for i in 0..3 {
+        let mut rng = StdRng::seed_from_u64(i as u64);
+        let solution = vec![1, 2, 3, 4];
+        let (_, _, token) = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<
+            SumModel,
+        >>::generate_trial(
+            &generator,
             &model,
-            vec![1, 2, 3, 4],
+            &solution,
             NotNan::new(10.0).unwrap(),
             &mut rng,
         );
-        generator.feedback(TrialOutcome::Improved);
+        generator.feedback(token, TrialOutcome::Improved);
     }
     // After segment ends, usage and accumulated scores must reset.
     let usage = generator.destroy_usage();
@@ -447,9 +478,8 @@ fn alns_generator_state_survives_step_with_generator() {
         handler,
         initial,
     );
-    // After the step, the generator's stacks must be empty (every
-    // `generate_trial` had its matching `feedback`) and the usage / scores
-    // must reflect the 10 trials that ran.
+    // The usage / scores must reflect the 10 trials that ran (one credit
+    // per iteration; tokens leave no pending state behind).
     let total_destroy_usage: usize = returned.destroy_usage().iter().sum();
     let total_repair_usage: usize = returned.repair_usage().iter().sum();
     assert_eq!(total_destroy_usage, 10);
@@ -475,4 +505,35 @@ fn alns_runs_through_generic_optimizer() {
     // The generator stored inside the optimizer must be the ALNS one.
     assert_eq!(optimizer.generator().n_destroy_operators(), 2);
     assert_eq!(optimizer.generator().n_repair_operators(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// ALNS with n_trials > 1: only the winner is credited per iteration and no
+// pending selections leak across iterations.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_with_multiple_trials_credits_only_winner_per_iteration() {
+    let model = SumModel::new(4, (0, 100));
+    let opt = LocalSearchLoop::new(100, 3, usize::MAX);
+    let handler = EpsilonGreedy::new(0.5);
+    let mut cb = |_p| {};
+    let initial = build_alns().with_segment_size(usize::MAX);
+    let (_, _, returned) = opt.step_with_generator(
+        &model,
+        vec![1, 2, 3, 4],
+        NotNan::new(10.0).unwrap(),
+        10,
+        Duration::from_secs(1),
+        &mut cb,
+        handler,
+        initial,
+    );
+    // One credit per iteration — not one per generated candidate.
+    // (Tokens carry the operator pair, so no pending state can leak and the
+    // winner is always credited.)
+    let total_destroy_usage: usize = returned.destroy_usage().iter().sum();
+    let total_repair_usage: usize = returned.repair_usage().iter().sum();
+    assert_eq!(total_destroy_usage, 10);
+    assert_eq!(total_repair_usage, 10);
 }

--- a/src/tests/test_alns.rs
+++ b/src/tests/test_alns.rs
@@ -1,0 +1,478 @@
+use std::time::Duration;
+
+use ordered_float::NotNan;
+use rand::{RngExt as _, distr::Uniform, prelude::Distribution};
+
+use super::QuadraticModel;
+use crate::{
+    LocalsearchError, OptModel,
+    optim::{
+        AlnsTrialGenerator, DefaultTrialGenerator, DestroyOperator, EpsilonGreedy,
+        GenericLocalSearchOptimizer, LocalSearchLoop, LocalSearchOptimizer, RepairOperator,
+        TrialGenerator, TrialOutcome,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Test model tailored for ALNS: each solution is a vector of `usize`s and the
+// score is the sum of the elements. Destroy operators zero out elements at a
+// set of positions and repair operators refill them with fresh random values.
+// ---------------------------------------------------------------------------
+
+type PartialSolution = Vec<Option<usize>>;
+
+#[derive(Clone)]
+struct SumModel {
+    n: usize,
+    value_range: (usize, usize),
+}
+
+impl SumModel {
+    fn new(n: usize, value_range: (usize, usize)) -> Self {
+        Self { n, value_range }
+    }
+
+    fn evaluate(&self, solution: &[usize]) -> NotNan<f64> {
+        let sum: usize = solution.iter().sum();
+        NotNan::new(sum as f64).expect("finite test score")
+    }
+}
+
+impl OptModel for SumModel {
+    type SolutionType = Vec<usize>;
+    type TransitionType = ();
+    type ScoreType = NotNan<f64>;
+
+    fn generate_random_solution<R: rand::Rng>(
+        &self,
+        rng: &mut R,
+    ) -> Result<(Self::SolutionType, Self::ScoreType), LocalsearchError> {
+        let dist = Uniform::new(self.value_range.0, self.value_range.1)
+            .expect("value range must be valid");
+        let solution = dist.sample_iter(rng).take(self.n).collect::<Vec<_>>();
+        let score = self.evaluate(&solution);
+        Ok((solution, score))
+    }
+
+    fn generate_trial_solution<R: rand::Rng>(
+        &self,
+        mut current_solution: Self::SolutionType,
+        _current_score: Self::ScoreType,
+        rng: &mut R,
+    ) -> (Self::SolutionType, Self::TransitionType, Self::ScoreType) {
+        // Touch a single random position so default-generator runs still work.
+        let k = rng.random_range(0..self.n);
+        let dist = Uniform::new(self.value_range.0, self.value_range.1)
+            .expect("value range must be valid");
+        current_solution[k] = dist.sample(rng);
+        let score = self.evaluate(&current_solution);
+        (current_solution, (), score)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Destroy / repair operator implementations used by the ALNS tests.
+// ---------------------------------------------------------------------------
+
+/// Destroy operator that zeroes out the first half of the solution.
+#[derive(Clone)]
+struct DestroyFirstHalf;
+
+impl DestroyOperator<SumModel, PartialSolution> for DestroyFirstHalf {
+    fn destroy(&self, _model: &SumModel, solution: Vec<usize>) -> PartialSolution {
+        let mut partial: PartialSolution = solution.into_iter().map(Some).collect();
+        let half = partial.len() / 2;
+        for v in partial.iter_mut().take(half) {
+            *v = None;
+        }
+        partial
+    }
+
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<SumModel, PartialSolution>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Destroy operator that zeroes out the second half of the solution.
+#[derive(Clone)]
+struct DestroySecondHalf;
+
+impl DestroyOperator<SumModel, PartialSolution> for DestroySecondHalf {
+    fn destroy(&self, _model: &SumModel, solution: Vec<usize>) -> PartialSolution {
+        let mut partial: PartialSolution = solution.into_iter().map(Some).collect();
+        let half = partial.len() / 2;
+        for v in partial.iter_mut().skip(half) {
+            *v = None;
+        }
+        partial
+    }
+
+    fn dyn_clone(&self) -> Box<dyn DestroyOperator<SumModel, PartialSolution>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Repair operator that fills `None` slots with values drawn from
+/// `[value_range.0, value_range.1)` and computes the resulting score.
+#[derive(Clone)]
+struct RandomRepair {
+    value_range: (usize, usize),
+}
+
+impl RepairOperator<SumModel, PartialSolution> for RandomRepair {
+    fn repair(&self, model: &SumModel, mut partial: PartialSolution) -> (Vec<usize>, NotNan<f64>) {
+        let mut rng = rand::rng();
+        let dist = Uniform::new(self.value_range.0, self.value_range.1)
+            .expect("value range must be valid");
+        for slot in partial.iter_mut() {
+            if slot.is_none() {
+                *slot = Some(dist.sample(&mut rng));
+            }
+        }
+        let solution = partial
+            .into_iter()
+            .map(|v| v.expect("repair must fill every slot"))
+            .collect::<Vec<_>>();
+        let score = model.evaluate(&solution);
+        (solution, score)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn RepairOperator<SumModel, PartialSolution>> {
+        Box::new(self.clone())
+    }
+}
+
+fn destroy_ops() -> Vec<Box<dyn DestroyOperator<SumModel, PartialSolution>>> {
+    vec![Box::new(DestroyFirstHalf), Box::new(DestroySecondHalf)]
+}
+
+fn repair_ops() -> Vec<Box<dyn RepairOperator<SumModel, PartialSolution>>> {
+    vec![Box::new(RandomRepair {
+        value_range: (0, 100),
+    })]
+}
+
+fn build_alns() -> AlnsTrialGenerator<SumModel, PartialSolution> {
+    AlnsTrialGenerator::new(destroy_ops(), repair_ops())
+}
+
+// ---------------------------------------------------------------------------
+// Default-generator behavior preserved through `step()`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_step_matches_legacy_behavior() {
+    // The legacy quadratic model keeps converging with hill climbing.
+    let model = QuadraticModel::new(3, vec![2.0, 0.0, -3.5], (-10.0, 10.0));
+    let opt = LocalSearchLoop::new(10_000, 10, usize::MAX);
+    let handler = EpsilonGreedy::new(0.0);
+    let mut cb = |_p| {};
+    let (result, _) = opt.step(
+        &model,
+        vec![0.0, 0.0, 0.0],
+        NotNan::new(2.0_f64.powf(2.0) + 3.5_f64.powf(2.0)).unwrap(),
+        200,
+        Duration::from_secs(5),
+        &mut cb,
+        handler,
+    );
+    // The greedy search must keep producing strictly non-increasing scores.
+    assert!(result.best_score.into_inner() < 30.0);
+    assert_eq!(result.best_solution.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Custom generator is invoked through `step_with_generator`.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct CountingGenerator {
+    generate_calls: usize,
+    feedback_calls: usize,
+    last_outcome: Option<TrialOutcome>,
+}
+
+impl TrialGenerator<QuadraticModel> for CountingGenerator {
+    fn generate_trial<R: rand::Rng>(
+        &mut self,
+        _model: &QuadraticModel,
+        current_solution: Vec<f64>,
+        current_score: NotNan<f64>,
+        _rng: &mut R,
+    ) -> (Vec<f64>, NotNan<f64>) {
+        self.generate_calls += 1;
+        // Nudge one coordinate; the loop still applies its acceptance logic.
+        let mut next = current_solution;
+        if !next.is_empty() {
+            next[0] += 0.1;
+        }
+        (next, current_score)
+    }
+
+    fn feedback(&mut self, outcome: TrialOutcome) {
+        self.feedback_calls += 1;
+        self.last_outcome = Some(outcome);
+    }
+}
+
+#[test]
+fn custom_generator_is_invoked_through_step_with_generator() {
+    let model = QuadraticModel::new(1, vec![0.0], (-1.0, 1.0));
+    let opt = LocalSearchLoop::new(10, 1, usize::MAX);
+    let handler = EpsilonGreedy::new(0.0);
+    let mut cb = |_p| {};
+    let generator = CountingGenerator::default();
+    let (_, _, returned) = opt.step_with_generator(
+        &model,
+        vec![0.5],
+        NotNan::new(0.25).unwrap(),
+        5,
+        Duration::from_secs(1),
+        &mut cb,
+        handler,
+        generator,
+    );
+    // n_iter iterations × n_trials per iteration.
+    assert_eq!(returned.generate_calls, 5);
+    assert_eq!(returned.feedback_calls, 5);
+    assert!(returned.last_outcome.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Existing `GenericLocalSearchOptimizer::new` call sites still compile and run.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_optimizer_new_still_works() {
+    let model = SumModel::new(4, (0, 100));
+    let optimizer = GenericLocalSearchOptimizer::new(1000, 1, usize::MAX, EpsilonGreedy::new(0.1));
+    // The default generator is the unit struct `DefaultTrialGenerator`.
+    let _: &DefaultTrialGenerator = optimizer.generator();
+    let (solution, score) = optimizer
+        .run(&model, None, 50, Duration::from_secs(1))
+        .unwrap();
+    assert_eq!(solution.len(), 4);
+    let sum: usize = solution.iter().sum();
+    assert_eq!(sum as f64, score.into_inner());
+}
+
+// ---------------------------------------------------------------------------
+// ALNS: operator selection follows weights.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_destroy_operator_selection_respects_weights() {
+    // With equal initial weights, both destroy operators should be picked
+    // roughly equally across many trials.
+    let model = SumModel::new(4, (0, 100));
+    let mut total_destroy_picks = [0usize, 0usize];
+    let mut total_repair_picks = [0usize; 1];
+    for _ in 0..2000 {
+        let mut local = build_alns().with_segment_size(usize::MAX);
+        let mut rng = rand::rng();
+        let (_solution, _score) =
+            <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
+                &mut local,
+                &model,
+                vec![1, 2, 3, 4],
+                NotNan::new(10.0).unwrap(),
+                &mut rng,
+            );
+        // Drain the stacks via feedback (we don't care about the outcome here).
+        local.feedback(TrialOutcome::Rejected);
+        // The destroy/repair stack should always have exactly one selection
+        // for each generate_trial call when n_trials == 1.
+        total_destroy_picks[0] += local.destroy_usage()[0];
+        total_destroy_picks[1] += local.destroy_usage()[1];
+        total_repair_picks[0] += local.repair_usage()[0];
+    }
+    // With equal initial weights, both destroy operators should be picked
+    // somewhere between 35 % and 65 % of the time across 2000 trials.
+    let total = (total_destroy_picks[0] + total_destroy_picks[1]) as f64;
+    let p0 = total_destroy_picks[0] as f64 / total;
+    let p1 = total_destroy_picks[1] as f64 / total;
+    assert!(
+        (0.35..=0.65).contains(&p0),
+        "destroy operator 0 selected {p0:.3}, expected ~0.5"
+    );
+    assert!(
+        (0.35..=0.65).contains(&p1),
+        "destroy operator 1 selected {p1:.3}, expected ~0.5"
+    );
+    // All repair picks go to the single repair operator.
+    assert_eq!(total_repair_picks[0], 2000);
+}
+
+// ---------------------------------------------------------------------------
+// ALNS: rewards are credited to the selected operators.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_feedback_credits_rewards_to_selected_operators() {
+    // Drop in two repair operators so we can verify the credit lands on the
+    // operator that was actually selected rather than smeared across all of
+    // them. Custom rewards make the per-outcome accounting easy to assert.
+    let mut generator = AlnsTrialGenerator::<SumModel, PartialSolution>::new(
+        destroy_ops(),
+        vec![
+            Box::new(RandomRepair {
+                value_range: (0, 100),
+            }),
+            Box::new(RandomRepair {
+                value_range: (0, 1),
+            }),
+        ],
+    )
+    .with_segment_size(usize::MAX)
+    .with_rewards(crate::optim::Rewards::new(20.0, 5.0, 2.0, 0.0));
+
+    let model = SumModel::new(4, (0, 100));
+
+    // Run a bunch of trials, observe that usage increments for both destroy
+    // and repair operators and that the accumulated scores reflect the
+    // rewards applied per outcome.
+    let mut total_score = 0.0_f64;
+    let mut total_usage = 0usize;
+    for &outcome in &[
+        TrialOutcome::NewBest,
+        TrialOutcome::Improved,
+        TrialOutcome::Accepted,
+        TrialOutcome::Rejected,
+    ] {
+        let mut local_rng = rand::rng();
+        let _ = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
+            &mut generator,
+            &model,
+            vec![1, 2, 3, 4],
+            NotNan::new(10.0).unwrap(),
+            &mut local_rng,
+        );
+        let expected_reward = match outcome {
+            TrialOutcome::NewBest => 20.0,
+            TrialOutcome::Improved => 5.0,
+            TrialOutcome::Accepted => 2.0,
+            TrialOutcome::Rejected => 0.0,
+        };
+        generator.feedback(outcome);
+        // After this feedback, *some* destroy and *some* repair operator was
+        // credited. Verify usage incremented and the aggregate reward is
+        // accumulated correctly across all operators.
+        let destroy_usage: usize = generator.destroy_usage().iter().sum();
+        let repair_usage: usize = generator.repair_usage().iter().sum();
+        assert_eq!(destroy_usage, repair_usage);
+        assert!(destroy_usage >= 1);
+        total_usage = destroy_usage;
+        let destroy_scores: f64 = generator.destroy_scores().iter().sum();
+        let repair_scores: f64 = generator.repair_scores().iter().sum();
+        // Destroy and repair scores are independent, but their usage matches.
+        total_score += expected_reward;
+        assert!(
+            (destroy_scores - total_score).abs() < 1e-9,
+            "destroy accumulated score {destroy_scores} != expected {total_score}"
+        );
+        assert!(
+            (repair_scores - total_score).abs() < 1e-9,
+            "repair accumulated score {repair_scores} != expected {total_score}"
+        );
+    }
+    assert_eq!(total_usage, 4);
+}
+
+// ---------------------------------------------------------------------------
+// ALNS: weights are updated at segment boundaries.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_updates_weights_at_segment_boundaries() {
+    let mut generator =
+        AlnsTrialGenerator::<SumModel, PartialSolution>::new(destroy_ops(), repair_ops())
+            .with_segment_size(3)
+            .with_reaction_factor(0.5);
+
+    let model = SumModel::new(4, (0, 100));
+    // Run 3 trials with reward 9 (Improved) each. With segment_size=3 and
+    // reaction_factor=0.5, after the third feedback the weights are blended
+    // with the segment average.
+    for _ in 0..3 {
+        let mut rng = rand::rng();
+        let _ = <AlnsTrialGenerator<SumModel, PartialSolution> as TrialGenerator<SumModel>>::generate_trial(
+            &mut generator,
+            &model,
+            vec![1, 2, 3, 4],
+            NotNan::new(10.0).unwrap(),
+            &mut rng,
+        );
+        generator.feedback(TrialOutcome::Improved);
+    }
+    // After segment ends, usage and accumulated scores must reset.
+    let usage = generator.destroy_usage();
+    let scores = generator.destroy_scores();
+    assert!(usage.iter().all(|&u| u == 0));
+    assert!(scores.iter().all(|&s| s == 0.0));
+    // trials_in_segment also resets.
+    assert_eq!(generator.trials_in_segment(), 0);
+    // Some destroy operator must have received a higher weight than another
+    // (or at minimum the weights are shifted from the initial 1.0).
+    let weights = generator.destroy_weights();
+    assert!(
+        weights.iter().any(|&w| (w - 1.0).abs() > 1e-12),
+        "weights must have been updated from initial value of 1.0, got {weights:?}"
+    );
+    // Repair weights also updated.
+    let repair_weights = generator.repair_weights();
+    assert_eq!(repair_weights.len(), 1);
+    // All repair trials went to the single repair operator, so its segment
+    // average was 9.0 -> new weight = (1 - 0.5) * 1.0 + 0.5 * 9.0 = 5.0.
+    assert!((repair_weights[0] - 5.0).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// ALNS: generator state survives the search step.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_generator_state_survives_step_with_generator() {
+    let model = SumModel::new(4, (0, 100));
+    let opt = LocalSearchLoop::new(100, 1, usize::MAX);
+    let handler = EpsilonGreedy::new(0.5);
+    let mut cb = |_p| {};
+    let initial = build_alns().with_segment_size(usize::MAX);
+    let (_, _, returned) = opt.step_with_generator(
+        &model,
+        vec![1, 2, 3, 4],
+        NotNan::new(10.0).unwrap(),
+        10,
+        Duration::from_secs(1),
+        &mut cb,
+        handler,
+        initial,
+    );
+    // After the step, the generator's stacks must be empty (every
+    // `generate_trial` had its matching `feedback`) and the usage / scores
+    // must reflect the 10 trials that ran.
+    let total_destroy_usage: usize = returned.destroy_usage().iter().sum();
+    let total_repair_usage: usize = returned.repair_usage().iter().sum();
+    assert_eq!(total_destroy_usage, 10);
+    assert_eq!(total_repair_usage, 10);
+}
+
+// ---------------------------------------------------------------------------
+// ALNS through `GenericLocalSearchOptimizer::with_trial_generator`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alns_runs_through_generic_optimizer() {
+    let model = SumModel::new(4, (0, 100));
+    let generator = build_alns().with_segment_size(usize::MAX);
+    let optimizer = GenericLocalSearchOptimizer::new(200, 1, usize::MAX, EpsilonGreedy::new(0.1))
+        .with_trial_generator(generator);
+    let (solution, score) = optimizer
+        .run(&model, None, 30, Duration::from_secs(1))
+        .unwrap();
+    assert_eq!(solution.len(), 4);
+    let sum: usize = solution.iter().sum();
+    assert_eq!(sum as f64, score.into_inner());
+    // The generator stored inside the optimizer must be the ALNS one.
+    assert_eq!(optimizer.generator().n_destroy_operators(), 2);
+    assert_eq!(optimizer.generator().n_repair_operators(), 1);
+}


### PR DESCRIPTION
## Summary

Adds Adaptive Large Neighborhood Search (ALNS) as a first-class optimizer in `localsearch`, plugged in through a new pluggable `TrialGenerator` abstraction that every existing optimizer shares. ALNS sits next to simulated annealing, tabu search, and the rest — instead of being a separate code path it reuses the same `LocalSearchLoop`, the same `TransitionHandler` machinery for acceptance, and the same `LocalSearchOptimizer` trait.

The PR ships two commits:

1. **Library** (`566e8c2`) — `TrialGenerator` trait, `AlnsTrialGenerator`, extended `GenericLocalSearchOptimizer`, tests, and docs. ~1.2 k lines across 7 source files.
2. **Example** (`cb27a4a`) — `examples/tsp_alns_model.rs` that exercises the new API on TSPLIB `berlin52` and reaches the exact optimum with default settings.

## How it is implemented

### Library

The ALNS feature lives at the trial-generation layer, not the acceptance layer. The acceptance side already supports any `TransitionHandler`; ALNS just contributes destroy/repair operator selection and the adaptive weight updates.

* **`src/optim/search_loop.rs`** — new `TrialGenerator` trait and `TrialOutcome` enum (`NewBest | Improved | Accepted | Rejected`). New `DefaultTrialGenerator` that delegates to `OptModel::generate_trial_solution`, so existing call sites compile unchanged. `LocalSearchLoop::step()` now forwards to a new `step_with_generator()` that accepts any user-supplied generator and returns it alongside the `StepResult` so adaptive state can survive across calls. The single-trial sequential generation in `step_with_generator` matches ALNS conventions (`n_trials = 1`).

* **`src/optim/alns.rs`** (new) — `AlnsTrialGenerator<M, P>` with:
  - independent destroy and repair operator pools (`Box<dyn DestroyOperator<_, _>>` and `Box<dyn RepairOperator<_, _>>`),
  - per-outcome `Rewards` table (default Ropke & Pisinger 33 / 9 / 13 / 0),
  - independent roulette-wheel weights for destroy and repair operators,
  - segment-based reaction-factor blending: every `segment_size` trials the weights are updated as `w_new = (1 − r) · w_old + r · (segment_score / usage_count)`, with non-positive weights floored to `1e-3`,
  - `with_segment_size`, `with_reaction_factor`, `with_rewards`, `with_destroy_rewards`, `with_repair_rewards` builders,
  - introspection accessors (`n_destroy_operators`, `destroy_weights`, `destroy_usage`, …).
  - `DestroyOperator` and `RepairOperator` traits stay object-safe via a `dyn_clone()` method (no `Clone` supertrait, since that would force `Self: Sized`). A blanket `impl Clone for Box<dyn DestroyOperator<…>>` delegates to `dyn_clone`, so operators only need `Clone` on the concrete type.

* **`src/optim/generic.rs`** — `GenericLocalSearchOptimizer` gains a third type parameter `G = DefaultTrialGenerator`. Existing `new(patience, n_trials, return_iter, handler)` call sites compile unchanged because of the default. New `with_trial_generator(generator)` builder swaps in ALNS or any other generator. Stored handler and generator are both treated as blueprints — cloned into each `optimize()` call, never mutated.

* **`src/optim.rs`** — re-exports `AlnsTrialGenerator`, `DestroyOperator`, `RepairOperator`, `Rewards` (and the existing `LocalSearchLoop`, `TrialGenerator`, `TrialOutcome`, `DefaultTrialGenerator`).

* **`src/tests/test_alns.rs`** (new, 478 lines) — 7 unit tests covering:
  - default-generator parity (`step()` still behaves like the legacy `step`),
  - custom generator dispatch through `step_with_generator`,
  - ALNS destroy-operator selection frequency respecting weights,
  - per-outcome reward crediting on the right operator,
  - segment-boundary weight blending and bookkeeping reset,
  - generator state surviving `step_with_generator`,
  - end-to-end ALNS through `GenericLocalSearchOptimizer::with_trial_generator`.

* **`API.md`** — new "Trial generators" section documenting `TrialGenerator`, `TrialOutcome`, `DefaultTrialGenerator`, the `step_with_generator` API, and the ALNS public surface.

* **Breaking change** — `LocalSearchLoop<ST>` is now plain `LocalSearchLoop` (`4f108c7`): the phantom `ST` parameter is gone. Downstream code that names the type explicitly (`LocalSearchLoop<NotNan<f64>>`, `LocalSearchLoop::<ST>::new`, type aliases, struct fields) must delete the type argument; inference-based call sites compile unchanged. Minor behavioral change: `LocalSearchLoop::new` now panics at construction on `n_trials == 0` (previously panicked on the first iteration). Must ship as a minor bump (`0.25.0+`), not a patch — `^0.24` consumers must not auto-update into the break.

* **Dependencies** — none added. `rand`, `rayon`, `ordered-float`, `thiserror`, `auto_impl` cover everything ALNS needs.

### Example

`examples/tsp_alns_model.rs` exercises every public piece of the new API on a real problem. It mirrors the structure of `examples/tsp_model.rs` so it can be read next to the existing ones.

**Model** — `TSPModel` stores a symmetric distance matrix in a `HashMap<Edge, f64>`. Solutions are tours shaped `[start, …, start]`. `generate_trial_solution` is a no-op because ALNS short-circuits trial generation through its own `TrialGenerator`.

**Destroy operators** (3):
- `RandomRemoval` — removes a random 5–15 % of interior cities.
- `WorstRemoval` — removes the cities whose removal saves the most distance (the "worst" positions in the current tour).
- `ShawRemoval` — picks a random seed city and removes the `n_remove` cities closest to it in the distance matrix (Shaw & Cordeau, 1997). Keeps the rest of the tour tightly connected and diversifies the destroy pool.

**Repair operators** (2):
- `GreedyInsertion` — inserts each removed city at the gap with the smallest insertion cost, then runs 2-opt local search to convergence. The 2-opt polish is the single biggest quality driver; greedy insertion alone plateaus several percent above optimum.
- `RandomInsertion` — inserts each removed city at a uniformly random gap. Kept for diversity, not polished.

**Partial state** — `(Vec<Option<usize>>, Vec<usize>)`: the tour with `None` slots plus the IDs of cities that were removed and still need reinsertion.

**ALNS wiring** — `AlnsTrialGenerator::new(destroy_ops, repair_ops).with_segment_size(100).with_reaction_factor(0.3)`. Default Ropke & Pisinger rewards.

**Acceptance** — `TsallisAnnealing` with β = 100, q = 2.0, ξ = 2.0, an adaptive scheduler targeting 10 % acceptance and a 100-iteration update interval. The `offset` is seeded from the initial random tour's score.

**Glue** — `GenericLocalSearchOptimizer::new(patience, 8, return_iter, handler).with_trial_generator(generator)`. Trials are generated in parallel on rayon with per-trial RNG forks; the best-scoring candidate is fed through acceptance and only its operator pair is credited (winner-takes-all via the trial token). 8 parallel trials is a deliberate best-of-k deviation from the single-trial textbook setting, trading credit granularity for throughput.

**CLI** — matches `tsp_model.rs`: positional `<input_file>` plus optional `<opt_route_file>`; on the latter the example prints the final score, the optimal score, and the percentage gap.

## Verification

```text
$ cargo run --release --example tsp_alns_model -- examples/tsp_berlin52/cities examples/tsp_berlin52/opt_route
run ALNS
ALNS: final score = 7544.365901904087, num of cities 53
optimal score = 7544.365901904087, num of cities 53
gap = 0.000%
```

- `cargo test` — 42 passed, 0 failed (7 tests in `test_alns.rs` plus tests added by the follow-up commits).
- `cargo clippy --example tsp_alns_model -- -D warnings` — clean.
- `cargo clippy -- -D warnings` (library) — clean.

## Diffstat

```text
 API.md                     |  31 ++-
 examples/tsp_alns_model.rs | 594 ++++++++++++++++++++++++++++++++++++++++++
 src/optim.rs               |   6 +-
 src/optim/alns.rs          | 511 ++++++++++++++++++++++++++++++++++++++
 src/optim/generic.rs       |  77 ++++--
 src/optim/search_loop.rs   | 167 +++++++++++--
 src/tests.rs               |   1 +
 src/tests/test_alns.rs     | 478 ++++++++++++++++++++++++++++++++++++
 8 files changed, 1825 insertions(+), 40 deletions(-)
```

## Post-review follow-ups

Added after the initial review round (the diffstat above reflects the two base commits only):

- `6435498` — **feat!: parallelize ALNS trial generation with token feedback.** `TrialGenerator::Token` carries the `(destroy, repair)` pair; only the winning candidate is credited per iteration (winner-takes-all).
- `a773fdc` — winning trial selected via rayon `min_by_key`; per-trial RNG forks drawn from a sequential seed stream keep runs reproducible.
- `c39b018` — example runs 8 parallel trials (best-of-k; see *Glue* above).
- `36600f8` — `TrialOutcome::NewBest` is credited even when the acceptance handler rejects the trial (best bookkeeping runs before acceptance).
- `a68de38` — `LocalSearchLoop::new` asserts `n_trials >= 1` at construction instead of panicking mid-run.
- `8cc597d` — best solution shared via `Rc<RefCell>`: O(1) per-iteration progress callbacks, matching `parallel_tempering`/`population_annealing`.
- `4f108c7` — **breaking:** `LocalSearchLoop<ST>` → `LocalSearchLoop`; `PhantomData<(M, P)>` dropped from `AlnsTrialGenerator` (removes a false `P: Sync` requirement on partial states).
- `5d7cb23` — docs: `OptProgress::solution` documented as a live shared view (`Rc<RefCell>`); clone before retaining past the callback.

Current totals vs `main`: `9 files changed, 2102 insertions(+), 57 deletions(-)`.
